### PR TITLE
Fix games-won stats using highest-score winner logic for lowest-score games

### DIFF
--- a/board_games_companion/lib/pages/playthroughs/playthrough_statistics_view_model.dart
+++ b/board_games_companion/lib/pages/playthroughs/playthrough_statistics_view_model.dart
@@ -309,19 +309,15 @@ abstract class _PlaythroughStatisticsViewModel with Store {
   ) {
     final Map<Player, int> playerWins = {};
     for (final Playthrough finishedPlaythrough in finishedPlaythroughs) {
-      final playthroughScores = playthroughScoresByPlaythroughId[finishedPlaythrough.id]
-              .onlyNumericalScores()
-              .sortByScore(gameFamily) ??
-          [];
-      if (playthroughScores.isEmpty) {
-        continue;
+      final playthroughWinnerScores =
+          playthroughScoresByPlaythroughId[finishedPlaythrough.id].winners(gameFamily);
+      for (final Score winnerScore in playthroughWinnerScores) {
+        final Player? winner = playersById[winnerScore.playerId];
+        if (winner == null) {
+          continue;
+        }
+        playerWins[winner] = (playerWins[winner] ?? 0) + 1;
       }
-
-      final Player? winner = playersById[playthroughScores.first.playerId];
-      if (winner == null) {
-        break;
-      }
-      playerWins[winner] = (playerWins[winner] ?? 0) + 1;
     }
 
     final playerWinsPercentage = <PlayerWinsStatistics>[];

--- a/board_games_companion/test/view_models/playthrough_statistics_view_model_test.dart
+++ b/board_games_companion/test/view_models/playthrough_statistics_view_model_test.dart
@@ -1,0 +1,110 @@
+import 'package:board_games_companion/common/enums/game_classification.dart';
+import 'package:board_games_companion/common/enums/game_family.dart';
+import 'package:board_games_companion/models/hive/player.dart';
+import 'package:board_games_companion/models/hive/playthrough.dart';
+import 'package:board_games_companion/models/hive/score.dart';
+import 'package:board_games_companion/models/hive/score_game_results.dart';
+import 'package:board_games_companion/pages/playthroughs/playthrough_statistics_view_model.dart';
+import 'package:board_games_companion/services/player_service.dart';
+import 'package:board_games_companion/stores/scores_store.dart';
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx/mobx.dart' show ObservableList;
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/game_playthroughs_details_store_mock.dart';
+
+void main() {
+  final mockPlayerService = MockPlayerService();
+  final mockScoresStore = MockScoresStore();
+  final mockGamePlaythroughsDetailsStore = MockGamePlaythroughsDetailsStore();
+
+  const playerOne = Player(id: '1', name: 'One');
+  const playerTwo = Player(id: '2', name: 'Two');
+  const playerThree = Player(id: '3', name: 'Three');
+
+  final playthrough = Playthrough(
+    id: 'playthrough-1',
+    boardGameId: 'board-game-1',
+    playerIds: [playerOne.id, playerTwo.id, playerThree.id],
+    scoreIds: const [],
+    startDate: clock.now().subtract(const Duration(hours: 1)),
+    endDate: clock.now(),
+  );
+
+  // MK Player one has the actual lowest score (and is recorded as place 1, the true winner),
+  // while player three has the highest score/value. Under GameFamily.LowestScore, player one
+  // should be reported as the winner of the "games won" statistics.
+  final scores = [
+    Score(
+      id: 's1',
+      playerId: playerOne.id,
+      boardGameId: playthrough.boardGameId,
+      playthroughId: playthrough.id,
+      scoreGameResult: const ScoreGameResult(place: 1, points: 3),
+    ),
+    Score(
+      id: 's2',
+      playerId: playerTwo.id,
+      boardGameId: playthrough.boardGameId,
+      playthroughId: playthrough.id,
+      scoreGameResult: const ScoreGameResult(place: 2, points: 7),
+    ),
+    Score(
+      id: 's3',
+      playerId: playerThree.id,
+      boardGameId: playthrough.boardGameId,
+      playthroughId: playthrough.id,
+      scoreGameResult: const ScoreGameResult(place: 3, points: 10),
+    ),
+  ];
+
+  late PlaythroughStatisticsViewModel playthroughStatisticsViewModel;
+
+  setUp(() {
+    when(() => mockPlayerService.retrievePlayers(includeDeleted: true)).thenAnswer(
+      (_) async => [playerOne, playerTwo, playerThree],
+    );
+    when(() => mockScoresStore.scores).thenReturn(ObservableList.of(scores));
+    when(() => mockGamePlaythroughsDetailsStore.playthroughs).thenReturn([playthrough]);
+    when(() => mockGamePlaythroughsDetailsStore.finishedPlaythroughs).thenReturn([playthrough]);
+    when(() => mockGamePlaythroughsDetailsStore.boardGameId).thenReturn(playthrough.boardGameId);
+    when(() => mockGamePlaythroughsDetailsStore.boardGameName).thenReturn('Test Game');
+    when(() => mockGamePlaythroughsDetailsStore.boardGameImageUrl).thenReturn(null);
+    when(() => mockGamePlaythroughsDetailsStore.gameClassification)
+        .thenReturn(GameClassification.Score);
+    when(() => mockGamePlaythroughsDetailsStore.gameGameFamily)
+        .thenReturn(GameFamily.LowestScore);
+    when(() => mockGamePlaythroughsDetailsStore.averageScorePrecision).thenReturn(0);
+
+    playthroughStatisticsViewModel = PlaythroughStatisticsViewModel(
+      mockPlayerService,
+      mockScoresStore,
+      mockGamePlaythroughsDetailsStore,
+    );
+  });
+
+  test(
+      'GIVEN a board game with GameFamily.LowestScore '
+      'AND a finished playthrough where the lowest score has place 1 '
+      'WHEN loading board game statistics '
+      'THEN the "games won" statistics should credit the actual (lowest-score) winner ',
+      () async {
+    playthroughStatisticsViewModel.loadBoardGamesStatistics();
+    await playthroughStatisticsViewModel.futureLoadBoardGamesStatistics;
+
+    final playerWinsPercentage = playthroughStatisticsViewModel.boardGameStatistics.maybeWhen(
+      score: (boardGameStatistics) => boardGameStatistics.playerWinsPercentage,
+      orElse: () => null,
+    );
+
+    expect(playerWinsPercentage, isNotNull);
+    expect(playerWinsPercentage!.length, 1);
+    expect(playerWinsPercentage.first.player, playerOne);
+    expect(playerWinsPercentage.first.numberOfWins, 1);
+  });
+}
+
+class MockPlayerService extends Mock implements PlayerService {}
+
+class MockScoresStore extends Mock implements ScoresStore {}


### PR DESCRIPTION
## Summary
- `_retrievePlayerWinsPercentage` (feeds the "games won" circle graph) picked the playthrough winner via `sortByScore(gameFamily).first`, which doesn't respect the recorded `place`/`isWinner` flag — so for `GameFamily.LowestScore` games it could credit the highest-scoring player instead of the actual (lowest-score) winner.
- Switched it to use the `winners(gameFamily)` extension, the same direction-agnostic winner lookup already used correctly for the "last winner" card, so the graph now credits the actual winner regardless of scoring direction.

Fixes #288

## Test plan
- [x] Added `test/view_models/playthrough_statistics_view_model_test.dart`: drives `loadBoardGamesStatistics()` for a `GameFamily.LowestScore` game where the lowest-score player has `place: 1`; fails red before the fix (credits the highest-score player), passes green after.
- [x] `flutter test` — full suite passes except one pre-existing, unrelated failure (`board_game_details_page_test.dart`, a `font_awesome_flutter`/Dart final-class incompatibility present on `main` before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)