### PR TITLE
docs: player statistics language and the pairwise head-to-head decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,3 +57,40 @@ _Avoid_: Local data, app data, user data
 **Legacy store**:
 The Hive files predating the SQLite migration. Read-only, imported once on launch, and retained indefinitely because old backups still contain them.
 _Avoid_: Old database, Hive box, legacy database
+
+### Statistics
+
+**Competitive play**:
+A playthrough of a game whose players are ranked against each other, so exactly one place is first. The only kind of play that can say anything about one player relative to another.
+_Avoid_: Versus game, PvP, scored game
+
+**Co-op play**:
+A playthrough whose players share a single outcome — the whole table wins or the whole table loses. Nobody beats anybody.
+_Avoid_: Cooperative game, team game, no-score game
+
+**Recorded result**:
+A player's outcome in a playthrough that is definite enough to count towards their statistics — a place in a competitive play, a shared outcome in a co-op play. A play in progress or missing outcomes has no recorded result and is invisible to every statistic.
+_Avoid_: Finished score, valid score, complete play
+
+**Competitive win rate**:
+The share of a player's competitive plays they finished first in, ties included. Kept apart from co-op because a co-op outcome belongs to the table rather than the player, and blending the two produces a number that cannot be compared between players.
+_Avoid_: Win %, win ratio
+
+**Co-op win rate**:
+The share of a player's co-op plays the table won. A property of the groups a player plays with as much as of the player.
+
+**Head-to-head record**:
+Two players' wins and losses against each other, counted a pair at a time within the competitive plays they shared. Finishing above someone is a win against them regardless of who else was at the table.
+_Avoid_: Matchup, H2H, record
+
+**Rival**:
+The player someone has beaten most across their head-to-head records. Rivalry is not symmetric — your rival's rival is rarely you.
+_Avoid_: Favourite victim, best matchup
+
+**Nemesis**:
+The player someone has lost to most across their head-to-head records.
+_Avoid_: Worst matchup, bogey player
+
+**Buddy**:
+A player someone has shared the most playthroughs with, of any kind. Measures company kept, not results, so co-op plays count exactly as much as competitive ones.
+_Avoid_: Frequent player, teammate, partner

--- a/docs/adr/0004-pairwise-head-to-head-player-statistics.md
+++ b/docs/adr/0004-pairwise-head-to-head-player-statistics.md
@@ -1,0 +1,22 @@
+# Player statistics are pairwise, and win rate is split by play type
+
+Personal player statistics ([#164](https://github.com/Progrunning/BoardGamesCompanion/issues/164)) report a **rival**, a **nemesis** and a **competitive win rate** — three numbers that only exist once you decide what "beating someone" means. We count **head-to-head records** pairwise: within each **competitive play**, a player beats everyone placed below them and loses to everyone above, so a fifth-place finish in a six-player game still produces a win. And we report **competitive win rate** and **co-op win rate** as two separate figures rather than one blended percentage.
+
+## Status
+
+accepted
+
+## Considered options
+
+- **Winner-takes-all head-to-heads** (rejected: only the first place records anything, so everyone at a table shares the same nemesis — whoever wins most — and the stat says nothing about the player it is shown to). Pairwise is O(players²) per play instead of O(players), which is irrelevant at the table sizes board games have.
+- **A single blended win rate over all plays** (rejected: a **co-op play** outcome belongs to the table, so a player whose history is mostly co-op has a win rate driven by the groups they join. Two players' blended rates are not comparable, and users would read the difference as a bug rather than as a difference in what they play).
+- **Ranking rival and nemesis by rate instead of count** (rejected: a rate crowns a nemesis off one unlucky evening. Count matches the plain-English "person I lost to most", with a floor of three shared **competitive plays** to suppress the same one-off result, and the record displayed alongside the name so the rate stays visible without driving the ranking).
+
+## Consequences
+
+- **Ties at first place count as a win for every tied player.** The alternative — splitting a win, or awarding it to nobody — makes the wins column stop summing to anything a user can verify against their own play history.
+- **A play's `GameFamily` is an input to every win statistic.** Whether a **recorded result** means a place or a shared outcome is a property of the board game's settings, not of the score, so aggregating a player across their whole history joins scores to playthroughs to board game settings. There is no path to these numbers from the scores alone.
+- **Plays imported from BGG carry points but no place.** `playthroughs_view_model.dart` builds `ScoreGameResult` without one, so `Score.isWinner` — defined as `place == 1` — is false for every imported competitive play. Win statistics must derive the winner by ordering scores within the play, as `ScoresExtesions.winners` already does. That fallback currently returns a single winner and so drops ties; it has one production caller, which already accepts a list, and fixing it is a prerequisite for this work rather than a refactor alongside it.
+- **Soft-deleted players stay in the aggregates.** A deleted player really did win those games, and dropping them would make one screen's totals disagree with another's. Soft-deleted playthroughs are excluded everywhere — those are retracted history, not history about someone who left.
+- **Sections below their threshold are hidden, not shown empty.** With the three-play floor on rivalry, a new player's page would otherwise be five cards of placeholders, which reads as a broken screen rather than as a young history.
+- **Statistics are all-time.** The period selector on the Plays statistics tab is deliberately not reused here yet; adding it later means introducing an "all time" option to the shared period vocabulary so both surfaces describe periods the same way.


### PR DESCRIPTION
Documentation only — no app code changes. Groundwork for #355 (personal player statistics page), which supersedes #164.

## What's here

**`CONTEXT.md` — new Statistics glossary section.** Competitive play, co-op play, recorded result, competitive win rate, co-op win rate, head-to-head record, rival, nemesis, buddy. The `_Avoid_` entries do real work: they steer off "win %" as a single blended number, which is the exact ambiguity the feature design hinges on.

**`docs/adr/0004-pairwise-head-to-head-player-statistics.md`.** Records the two decisions that are hard to reverse and surprising on sight:

- **Head-to-heads are pairwise.** In a competitive play you beat everyone placed below you and lose to everyone above. The rejected alternative — winner-takes-all — makes everyone at a table share the same nemesis, so the stat says nothing about the player it's shown to.
- **Win rate is two figures, never blended.** A co-op outcome belongs to the table, so a blended rate isn't comparable between two players and reads as a bug rather than as a difference in what they play.

Consequences capture the things that will bite an implementer: winner determination needs the board game's `GameFamily`, not just the scores; BGG-imported plays record points but no place, so the existing winners helper's tie-dropping fallback has to be fixed first or imported histories show a win rate of zero; and soft deletes are asymmetric (deleted players stay in aggregates, deleted playthroughs don't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
