### PR TITLE
Personal player statistics page (#355)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,3 +57,41 @@ _Avoid_: Local data, app data, user data
 **Legacy store**:
 The Hive files predating the SQLite migration. Read-only, imported once on launch, and retained indefinitely because old backups still contain them.
 _Avoid_: Old database, Hive box, legacy database
+
+### Statistics
+
+**Competitive play**:
+A finished, non-deleted playthrough of a game whose settings classify it as scored (not cooperative). The scores establish an ordering, so one player can be said to finish above another.
+_Avoid_: Versus game, scored game, ranked play
+
+**Co-op play**:
+A finished, non-deleted playthrough of a game whose settings classify it as cooperative. The result — win or loss — belongs to the whole table, not to any one player.
+_Avoid_: Cooperative game, team play, no-score play
+
+**Solo play**:
+A play with a single participant. Counted in a player's total plays, but excluded from their competitive win rate because there is no opposition to beat.
+_Avoid_: Single-player game, one-player play
+
+**Competitive win rate**:
+The fraction of a player's multiplayer competitive plays that they won, ties for first counting as a win. Reported separately and never blended with the co-op win rate.
+_Avoid_: Win rate, win percentage, win ratio
+
+**Co-op win rate**:
+The fraction of a player's co-op plays the table won. A whole-table outcome, kept apart from the competitive win rate so a run of hard co-op games does not drag a strong competitive record down.
+_Avoid_: Win rate, cooperative percentage
+
+**Head-to-head record**:
+Between two players, how many competitive plays one finished above the other and how many below, shown as a wins–losses pair. Beating someone means finishing above them, not only winning the play.
+_Avoid_: Matchup, score line, record
+
+**Rival**:
+The opponent a player has beaten most across their shared competitive plays, considered only once the two have met in at least three competitive plays. A player's rival rarely has that player as their own rival — the relation is directional.
+_Avoid_: Best matchup, favourite opponent
+
+**Nemesis**:
+The opponent a player has lost to most across their shared competitive plays, subject to the same three-play floor as the rival.
+_Avoid_: Arch-enemy, worst matchup
+
+**Buddy**:
+Someone a player has shared the most playthroughs with, co-op and competitive alike. The five buddies with the highest shared-play counts are shown.
+_Avoid_: Friend, teammate, frequent player

--- a/board_games_companion/lib/app.dart
+++ b/board_games_companion/lib/app.dart
@@ -11,6 +11,7 @@ import 'models/navigation/board_game_details_page_arguments.dart';
 import 'models/navigation/create_board_game_page_arguments.dart';
 import 'models/navigation/edit_playthrough_page_arguments.dart';
 import 'models/navigation/player_page_arguments.dart';
+import 'models/navigation/player_statistics_page_arguments.dart';
 import 'models/navigation/playthough_note_page_arguments.dart';
 import 'models/navigation/playthrough_migration_page_arguments.dart';
 import 'models/navigation/playthroughs_page_arguments.dart';
@@ -29,6 +30,8 @@ import 'pages/home/home_page.dart';
 import 'pages/home/home_view_model.dart';
 import 'pages/player/player_page.dart';
 import 'pages/player/player_view_model.dart';
+import 'pages/player_statistics/player_statistics_page.dart';
+import 'pages/player_statistics/player_statistics_view_model.dart';
 import 'pages/playthroughs/playthrough_migration_page.dart';
 import 'pages/playthroughs/playthrough_migration_view_model.dart';
 import 'pages/playthroughs/playthrough_players_selection_page.dart';
@@ -112,6 +115,16 @@ class BoardGamesCompanionAppState extends State<BoardGamesCompanionApp> {
             return MaterialPageRoute<dynamic>(
               settings: routeSettings,
               builder: (BuildContext context) => PlayerPage(viewModel: playersViewModel),
+            );
+
+          case PlayerStatisticsPage.pageRoute:
+            final arguments = routeSettings.arguments as PlayerStatisticsPageArguments;
+            final viewModel = getIt<PlayerStatisticsViewModel>();
+            viewModel.setPlayer(arguments.player);
+
+            return MaterialPageRoute<dynamic>(
+              settings: routeSettings,
+              builder: (BuildContext context) => PlayerStatisticsPage(viewModel: viewModel),
             );
 
           case PlaythroughsPage.pageRoute:

--- a/board_games_companion/lib/common/app_text.dart
+++ b/board_games_companion/lib/common/app_text.dart
@@ -251,6 +251,19 @@ class AppText {
   static const playerPagePlayerRestoreSuccessfully = 'Player restored successfully';
   static const playerPagePlayerRestoreFailure = 'Failed to restore deleted player';
 
+  static const playerStatisticsPageNoPlaysTitle = "This player hasn't logged any plays yet";
+  static const playerStatisticsPageTotalPlays = 'Plays';
+  static const playerStatisticsPageTotalWins = 'Wins';
+  static const playerStatisticsPageCompetitiveWinRate = 'Competitive win rate';
+  static const playerStatisticsPageCoopWinRate = 'Co-op win rate';
+  static const playerStatisticsPageGamesSectionTitle = 'Games';
+  static const playerStatisticsPageGamesShowMore = 'Show more';
+  static const playerStatisticsPageGamesShowLess = 'Show less';
+  static const playerStatisticsPageRivalSectionTitle = 'Rival';
+  static const playerStatisticsPageNemesisSectionTitle = 'Nemesis';
+  static const playerStatisticsPageBuddiesSectionTitle = 'Buddies';
+  static const playerStatisticsPageBuddiesSharedPlays = 'Shared plays';
+
   static const playersPageTitle = 'Players';
   static const playersPageCreatePlayerButtonText = 'Create';
   static const playersPageSearchPlayerButtonText = 'Search';

--- a/board_games_companion/lib/extensions/route_extensions.dart
+++ b/board_games_companion/lib/extensions/route_extensions.dart
@@ -8,6 +8,7 @@ import '../pages/edit_playthrough/edit_playthrough_page.dart';
 import '../pages/edit_playthrough/playthrough_note_page.dart';
 import '../pages/home/home_page.dart';
 import '../pages/player/player_page.dart';
+import '../pages/player_statistics/player_statistics_page.dart';
 import '../pages/plays/game_spinner_game_selected_dialog.dart';
 import '../pages/playthroughs/bgg_plays_import_report_dialog.dart';
 import '../pages/playthroughs/playthrough_migration_page.dart';
@@ -32,6 +33,8 @@ extension RouteExtensions on Route<dynamic> {
         return 'Playthrough Note';
       case PlayerPage.pageRoute:
         return 'Player';
+      case PlayerStatisticsPage.pageRoute:
+        return 'Player Statistics';
       case SettingsPage.pageRoute:
         return 'Settings';
       case CreateBoardGamePage.pageRoute:
@@ -67,6 +70,8 @@ extension RouteExtensions on Route<dynamic> {
         return 'PlaythroughNotePage';
       case PlayerPage.pageRoute:
         return 'PlayerPage';
+      case PlayerStatisticsPage.pageRoute:
+        return 'PlayerStatisticsPage';
       case SettingsPage.pageRoute:
         return 'SettingsPage';
       case CreateBoardGamePage.pageRoute:

--- a/board_games_companion/lib/extensions/scores_extensions.dart
+++ b/board_games_companion/lib/extensions/scores_extensions.dart
@@ -24,11 +24,13 @@ extension ScoresExtesions on Iterable<Score>? {
   List<Score> winners(GameFamily gameFamily) {
     var winners = this?.onlyNumericalScores().where((s) => s.isWinner).toList();
 
-    // Get the winner by ordering scores highest/lowest and taking the top one
+    // Get the winner(s) by ordering scores highest/lowest and taking all scores tied
+    // for the top spot
     if (winners?.isEmpty ?? true) {
       final orderedScores = this?.onlyNumericalScores().sortByScore(gameFamily);
       if (orderedScores?.isNotEmpty ?? false) {
-        winners = [orderedScores!.first];
+        final bestScore = orderedScores!.first.score;
+        winners = orderedScores.where((s) => s.score == bestScore).toList();
       }
     }
 

--- a/board_games_companion/lib/injectable.config.dart
+++ b/board_games_companion/lib/injectable.config.dart
@@ -23,6 +23,7 @@ import 'pages/edit_playthrough/playthrough_note_view_model.dart' as _i181;
 import 'pages/home/home_view_model.dart' as _i768;
 import 'pages/hot_board_games/hot_board_games_view_model.dart' as _i24;
 import 'pages/player/player_view_model.dart' as _i316;
+import 'pages/player_statistics/player_statistics_view_model.dart' as _i527;
 import 'pages/players/players_view_model.dart' as _i441;
 import 'pages/plays/plays_view_model.dart' as _i877;
 import 'pages/playthroughs/playthrough_migration_view_model.dart' as _i272;
@@ -43,6 +44,7 @@ import 'services/environment_service.dart' as _i566;
 import 'services/file_service.dart' as _i207;
 import 'services/injectable_register_module.dart' as _i837;
 import 'services/player_service.dart' as _i29;
+import 'services/player_statistics_service.dart' as _i709;
 import 'services/playthroughs_service.dart' as _i934;
 import 'services/preferences_service.dart' as _i701;
 import 'services/rate_and_review_service.dart' as _i93;
@@ -76,7 +78,7 @@ _i174.GetIt $initGetIt(
   gh.factory<_i181.PlaythroughNoteViewModel>(
       () => _i181.PlaythroughNoteViewModel());
   gh.factory<_i979.HiveInterface>(() => registerModule.hive);
-  gh.singleton<_i207.FileService>(() => _i207.FileService());
+  gh.singleton<_i947.AppStore>(() => _i947.AppStore());
   gh.singleton<_i398.FirebaseAnalytics>(() => registerModule.firebaseAnalytics);
   gh.singleton<_i398.FirebaseAnalyticsObserver>(
       () => registerModule.firebaseAnalyticsObserver);
@@ -84,7 +86,7 @@ _i174.GetIt $initGetIt(
       () => registerModule.environmentService);
   gh.singleton<_i667.BoardGamesGeekService>(
       () => registerModule.boardGameGeekService);
-  gh.singleton<_i947.AppStore>(() => _i947.AppStore());
+  gh.singleton<_i207.FileService>(() => _i207.FileService());
   gh.singleton<_i927.BoardGamesService>(() => _i927.BoardGamesService(
         gh<_i979.HiveInterface>(),
         gh<_i667.BoardGamesGeekService>(),
@@ -97,14 +99,14 @@ _i174.GetIt $initGetIt(
       ));
   gh.singleton<_i75.BoardGamesSearchService>(
       () => _i75.BoardGamesSearchService(gh<_i566.EnvironmentService>()));
-  gh.singleton<_i701.PreferencesService>(
-      () => _i701.PreferencesService(gh<_i979.HiveInterface>()));
-  gh.singleton<_i277.ScoreService>(
-      () => _i277.ScoreService(gh<_i979.HiveInterface>()));
   gh.singleton<_i153.SearchService>(
       () => _i153.SearchService(gh<_i979.HiveInterface>()));
   gh.singleton<_i2.UserService>(
       () => _i2.UserService(gh<_i979.HiveInterface>()));
+  gh.singleton<_i277.ScoreService>(
+      () => _i277.ScoreService(gh<_i979.HiveInterface>()));
+  gh.singleton<_i701.PreferencesService>(
+      () => _i701.PreferencesService(gh<_i979.HiveInterface>()));
   gh.singleton<_i93.RateAndReviewService>(
       () => _i93.RateAndReviewService(gh<_i701.PreferencesService>()));
   gh.singleton<_i385.AnalyticsService>(() => _i385.AnalyticsService(
@@ -141,6 +143,12 @@ _i174.GetIt $initGetIt(
         gh<_i927.BoardGamesService>(),
         gh<_i934.PlaythroughService>(),
       ));
+  gh.factory<_i709.PlayerStatisticsService>(() => _i709.PlayerStatisticsService(
+        gh<_i182.PlayersStore>(),
+        gh<_i85.PlaythroughsStore>(),
+        gh<_i145.ScoresStore>(),
+        gh<_i839.BoardGamesStore>(),
+      ));
   gh.factory<_i877.PlaysViewModel>(() => _i877.PlaysViewModel(
         gh<_i85.PlaythroughsStore>(),
         gh<_i839.BoardGamesStore>(),
@@ -148,12 +156,20 @@ _i174.GetIt $initGetIt(
         gh<_i145.ScoresStore>(),
         gh<_i385.AnalyticsService>(),
       ));
-  gh.factory<_i316.PlayerViewModel>(
-      () => _i316.PlayerViewModel(gh<_i182.PlayersStore>()));
   gh.factory<_i441.PlayersViewModel>(
       () => _i441.PlayersViewModel(gh<_i182.PlayersStore>()));
   gh.factory<_i950.PlaythroughPlayersSelectionViewModel>(() =>
       _i950.PlaythroughPlayersSelectionViewModel(gh<_i182.PlayersStore>()));
+  gh.factory<_i316.PlayerViewModel>(
+      () => _i316.PlayerViewModel(gh<_i182.PlayersStore>()));
+  gh.factory<_i527.PlayerStatisticsViewModel>(
+      () => _i527.PlayerStatisticsViewModel(
+            gh<_i709.PlayerStatisticsService>(),
+            gh<_i182.PlayersStore>(),
+            gh<_i85.PlaythroughsStore>(),
+            gh<_i145.ScoresStore>(),
+            gh<_i839.BoardGamesStore>(),
+          ));
   gh.singleton<_i585.SettingsViewModel>(() => _i585.SettingsViewModel(
         gh<_i207.FileService>(),
         gh<_i927.BoardGamesService>(),

--- a/board_games_companion/lib/models/navigation/player_statistics_page_arguments.dart
+++ b/board_games_companion/lib/models/navigation/player_statistics_page_arguments.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../hive/player.dart';
+
+part 'player_statistics_page_arguments.freezed.dart';
+
+@freezed
+class PlayerStatisticsPageArguments with _$PlayerStatisticsPageArguments {
+  const factory PlayerStatisticsPageArguments({
+    required Player player,
+  }) = _PlayerStatisticsPageArguments;
+}

--- a/board_games_companion/lib/models/navigation/player_statistics_page_arguments.freezed.dart
+++ b/board_games_companion/lib/models/navigation/player_statistics_page_arguments.freezed.dart
@@ -1,0 +1,157 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'player_statistics_page_arguments.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$PlayerStatisticsPageArguments {
+  Player get player => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $PlayerStatisticsPageArgumentsCopyWith<PlayerStatisticsPageArguments>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PlayerStatisticsPageArgumentsCopyWith<$Res> {
+  factory $PlayerStatisticsPageArgumentsCopyWith(
+          PlayerStatisticsPageArguments value,
+          $Res Function(PlayerStatisticsPageArguments) then) =
+      _$PlayerStatisticsPageArgumentsCopyWithImpl<$Res,
+          PlayerStatisticsPageArguments>;
+  @useResult
+  $Res call({Player player});
+
+  $PlayerCopyWith<$Res> get player;
+}
+
+/// @nodoc
+class _$PlayerStatisticsPageArgumentsCopyWithImpl<$Res,
+        $Val extends PlayerStatisticsPageArguments>
+    implements $PlayerStatisticsPageArgumentsCopyWith<$Res> {
+  _$PlayerStatisticsPageArgumentsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? player = null,
+  }) {
+    return _then(_value.copyWith(
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerCopyWith<$Res> get player {
+    return $PlayerCopyWith<$Res>(_value.player, (value) {
+      return _then(_value.copyWith(player: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PlayerStatisticsPageArgumentsImplCopyWith<$Res>
+    implements $PlayerStatisticsPageArgumentsCopyWith<$Res> {
+  factory _$$PlayerStatisticsPageArgumentsImplCopyWith(
+          _$PlayerStatisticsPageArgumentsImpl value,
+          $Res Function(_$PlayerStatisticsPageArgumentsImpl) then) =
+      __$$PlayerStatisticsPageArgumentsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Player player});
+
+  @override
+  $PlayerCopyWith<$Res> get player;
+}
+
+/// @nodoc
+class __$$PlayerStatisticsPageArgumentsImplCopyWithImpl<$Res>
+    extends _$PlayerStatisticsPageArgumentsCopyWithImpl<$Res,
+        _$PlayerStatisticsPageArgumentsImpl>
+    implements _$$PlayerStatisticsPageArgumentsImplCopyWith<$Res> {
+  __$$PlayerStatisticsPageArgumentsImplCopyWithImpl(
+      _$PlayerStatisticsPageArgumentsImpl _value,
+      $Res Function(_$PlayerStatisticsPageArgumentsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? player = null,
+  }) {
+    return _then(_$PlayerStatisticsPageArgumentsImpl(
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PlayerStatisticsPageArgumentsImpl
+    implements _PlayerStatisticsPageArguments {
+  const _$PlayerStatisticsPageArgumentsImpl({required this.player});
+
+  @override
+  final Player player;
+
+  @override
+  String toString() {
+    return 'PlayerStatisticsPageArguments(player: $player)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PlayerStatisticsPageArgumentsImpl &&
+            (identical(other.player, player) || other.player == player));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, player);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PlayerStatisticsPageArgumentsImplCopyWith<
+          _$PlayerStatisticsPageArgumentsImpl>
+      get copyWith => __$$PlayerStatisticsPageArgumentsImplCopyWithImpl<
+          _$PlayerStatisticsPageArgumentsImpl>(this, _$identity);
+}
+
+abstract class _PlayerStatisticsPageArguments
+    implements PlayerStatisticsPageArguments {
+  const factory _PlayerStatisticsPageArguments({required final Player player}) =
+      _$PlayerStatisticsPageArgumentsImpl;
+
+  @override
+  Player get player;
+  @override
+  @JsonKey(ignore: true)
+  _$$PlayerStatisticsPageArgumentsImplCopyWith<
+          _$PlayerStatisticsPageArgumentsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/board_games_companion/lib/models/player_overall_statistics.dart
+++ b/board_games_companion/lib/models/player_overall_statistics.dart
@@ -1,0 +1,51 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'hive/player.dart';
+
+part 'player_overall_statistics.freezed.dart';
+
+@freezed
+class PlayerOverallStatistics with _$PlayerOverallStatistics {
+  const factory PlayerOverallStatistics({
+    required Player player,
+    required int totalPlays,
+    required int totalWins,
+    double? competitiveWinRate,
+    double? coopWinRate,
+    @Default(<GamePlaysCount>[]) List<GamePlaysCount> gamesByPlays,
+    HeadToHeadRecord? rival,
+    HeadToHeadRecord? nemesis,
+    @Default(<BuddyRecord>[]) List<BuddyRecord> buddies,
+  }) = _PlayerOverallStatistics;
+
+  const PlayerOverallStatistics._();
+
+  bool get hasNoPlays => totalPlays == 0;
+}
+
+@freezed
+class GamePlaysCount with _$GamePlaysCount {
+  const factory GamePlaysCount({
+    required String boardGameId,
+    required String boardGameName,
+    String? boardGameImageUrl,
+    required int playCount,
+  }) = _GamePlaysCount;
+}
+
+@freezed
+class HeadToHeadRecord with _$HeadToHeadRecord {
+  const factory HeadToHeadRecord({
+    required Player opponent,
+    required int wins,
+    required int losses,
+  }) = _HeadToHeadRecord;
+}
+
+@freezed
+class BuddyRecord with _$BuddyRecord {
+  const factory BuddyRecord({
+    required Player buddy,
+    required int sharedPlaysCount,
+  }) = _BuddyRecord;
+}

--- a/board_games_companion/lib/models/player_overall_statistics.freezed.dart
+++ b/board_games_companion/lib/models/player_overall_statistics.freezed.dart
@@ -1,0 +1,881 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'player_overall_statistics.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$PlayerOverallStatistics {
+  Player get player => throw _privateConstructorUsedError;
+  int get totalPlays => throw _privateConstructorUsedError;
+  int get totalWins => throw _privateConstructorUsedError;
+  double? get competitiveWinRate => throw _privateConstructorUsedError;
+  double? get coopWinRate => throw _privateConstructorUsedError;
+  List<GamePlaysCount> get gamesByPlays => throw _privateConstructorUsedError;
+  HeadToHeadRecord? get rival => throw _privateConstructorUsedError;
+  HeadToHeadRecord? get nemesis => throw _privateConstructorUsedError;
+  List<BuddyRecord> get buddies => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $PlayerOverallStatisticsCopyWith<PlayerOverallStatistics> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PlayerOverallStatisticsCopyWith<$Res> {
+  factory $PlayerOverallStatisticsCopyWith(PlayerOverallStatistics value,
+          $Res Function(PlayerOverallStatistics) then) =
+      _$PlayerOverallStatisticsCopyWithImpl<$Res, PlayerOverallStatistics>;
+  @useResult
+  $Res call(
+      {Player player,
+      int totalPlays,
+      int totalWins,
+      double? competitiveWinRate,
+      double? coopWinRate,
+      List<GamePlaysCount> gamesByPlays,
+      HeadToHeadRecord? rival,
+      HeadToHeadRecord? nemesis,
+      List<BuddyRecord> buddies});
+
+  $PlayerCopyWith<$Res> get player;
+  $HeadToHeadRecordCopyWith<$Res>? get rival;
+  $HeadToHeadRecordCopyWith<$Res>? get nemesis;
+}
+
+/// @nodoc
+class _$PlayerOverallStatisticsCopyWithImpl<$Res,
+        $Val extends PlayerOverallStatistics>
+    implements $PlayerOverallStatisticsCopyWith<$Res> {
+  _$PlayerOverallStatisticsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? player = null,
+    Object? totalPlays = null,
+    Object? totalWins = null,
+    Object? competitiveWinRate = freezed,
+    Object? coopWinRate = freezed,
+    Object? gamesByPlays = null,
+    Object? rival = freezed,
+    Object? nemesis = freezed,
+    Object? buddies = null,
+  }) {
+    return _then(_value.copyWith(
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+      totalPlays: null == totalPlays
+          ? _value.totalPlays
+          : totalPlays // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalWins: null == totalWins
+          ? _value.totalWins
+          : totalWins // ignore: cast_nullable_to_non_nullable
+              as int,
+      competitiveWinRate: freezed == competitiveWinRate
+          ? _value.competitiveWinRate
+          : competitiveWinRate // ignore: cast_nullable_to_non_nullable
+              as double?,
+      coopWinRate: freezed == coopWinRate
+          ? _value.coopWinRate
+          : coopWinRate // ignore: cast_nullable_to_non_nullable
+              as double?,
+      gamesByPlays: null == gamesByPlays
+          ? _value.gamesByPlays
+          : gamesByPlays // ignore: cast_nullable_to_non_nullable
+              as List<GamePlaysCount>,
+      rival: freezed == rival
+          ? _value.rival
+          : rival // ignore: cast_nullable_to_non_nullable
+              as HeadToHeadRecord?,
+      nemesis: freezed == nemesis
+          ? _value.nemesis
+          : nemesis // ignore: cast_nullable_to_non_nullable
+              as HeadToHeadRecord?,
+      buddies: null == buddies
+          ? _value.buddies
+          : buddies // ignore: cast_nullable_to_non_nullable
+              as List<BuddyRecord>,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerCopyWith<$Res> get player {
+    return $PlayerCopyWith<$Res>(_value.player, (value) {
+      return _then(_value.copyWith(player: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $HeadToHeadRecordCopyWith<$Res>? get rival {
+    if (_value.rival == null) {
+      return null;
+    }
+
+    return $HeadToHeadRecordCopyWith<$Res>(_value.rival!, (value) {
+      return _then(_value.copyWith(rival: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $HeadToHeadRecordCopyWith<$Res>? get nemesis {
+    if (_value.nemesis == null) {
+      return null;
+    }
+
+    return $HeadToHeadRecordCopyWith<$Res>(_value.nemesis!, (value) {
+      return _then(_value.copyWith(nemesis: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PlayerOverallStatisticsImplCopyWith<$Res>
+    implements $PlayerOverallStatisticsCopyWith<$Res> {
+  factory _$$PlayerOverallStatisticsImplCopyWith(
+          _$PlayerOverallStatisticsImpl value,
+          $Res Function(_$PlayerOverallStatisticsImpl) then) =
+      __$$PlayerOverallStatisticsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {Player player,
+      int totalPlays,
+      int totalWins,
+      double? competitiveWinRate,
+      double? coopWinRate,
+      List<GamePlaysCount> gamesByPlays,
+      HeadToHeadRecord? rival,
+      HeadToHeadRecord? nemesis,
+      List<BuddyRecord> buddies});
+
+  @override
+  $PlayerCopyWith<$Res> get player;
+  @override
+  $HeadToHeadRecordCopyWith<$Res>? get rival;
+  @override
+  $HeadToHeadRecordCopyWith<$Res>? get nemesis;
+}
+
+/// @nodoc
+class __$$PlayerOverallStatisticsImplCopyWithImpl<$Res>
+    extends _$PlayerOverallStatisticsCopyWithImpl<$Res,
+        _$PlayerOverallStatisticsImpl>
+    implements _$$PlayerOverallStatisticsImplCopyWith<$Res> {
+  __$$PlayerOverallStatisticsImplCopyWithImpl(
+      _$PlayerOverallStatisticsImpl _value,
+      $Res Function(_$PlayerOverallStatisticsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? player = null,
+    Object? totalPlays = null,
+    Object? totalWins = null,
+    Object? competitiveWinRate = freezed,
+    Object? coopWinRate = freezed,
+    Object? gamesByPlays = null,
+    Object? rival = freezed,
+    Object? nemesis = freezed,
+    Object? buddies = null,
+  }) {
+    return _then(_$PlayerOverallStatisticsImpl(
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+      totalPlays: null == totalPlays
+          ? _value.totalPlays
+          : totalPlays // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalWins: null == totalWins
+          ? _value.totalWins
+          : totalWins // ignore: cast_nullable_to_non_nullable
+              as int,
+      competitiveWinRate: freezed == competitiveWinRate
+          ? _value.competitiveWinRate
+          : competitiveWinRate // ignore: cast_nullable_to_non_nullable
+              as double?,
+      coopWinRate: freezed == coopWinRate
+          ? _value.coopWinRate
+          : coopWinRate // ignore: cast_nullable_to_non_nullable
+              as double?,
+      gamesByPlays: null == gamesByPlays
+          ? _value._gamesByPlays
+          : gamesByPlays // ignore: cast_nullable_to_non_nullable
+              as List<GamePlaysCount>,
+      rival: freezed == rival
+          ? _value.rival
+          : rival // ignore: cast_nullable_to_non_nullable
+              as HeadToHeadRecord?,
+      nemesis: freezed == nemesis
+          ? _value.nemesis
+          : nemesis // ignore: cast_nullable_to_non_nullable
+              as HeadToHeadRecord?,
+      buddies: null == buddies
+          ? _value._buddies
+          : buddies // ignore: cast_nullable_to_non_nullable
+              as List<BuddyRecord>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PlayerOverallStatisticsImpl extends _PlayerOverallStatistics {
+  const _$PlayerOverallStatisticsImpl(
+      {required this.player,
+      required this.totalPlays,
+      required this.totalWins,
+      this.competitiveWinRate,
+      this.coopWinRate,
+      final List<GamePlaysCount> gamesByPlays = const <GamePlaysCount>[],
+      this.rival,
+      this.nemesis,
+      final List<BuddyRecord> buddies = const <BuddyRecord>[]})
+      : _gamesByPlays = gamesByPlays,
+        _buddies = buddies,
+        super._();
+
+  @override
+  final Player player;
+  @override
+  final int totalPlays;
+  @override
+  final int totalWins;
+  @override
+  final double? competitiveWinRate;
+  @override
+  final double? coopWinRate;
+  final List<GamePlaysCount> _gamesByPlays;
+  @override
+  @JsonKey()
+  List<GamePlaysCount> get gamesByPlays {
+    if (_gamesByPlays is EqualUnmodifiableListView) return _gamesByPlays;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_gamesByPlays);
+  }
+
+  @override
+  final HeadToHeadRecord? rival;
+  @override
+  final HeadToHeadRecord? nemesis;
+  final List<BuddyRecord> _buddies;
+  @override
+  @JsonKey()
+  List<BuddyRecord> get buddies {
+    if (_buddies is EqualUnmodifiableListView) return _buddies;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_buddies);
+  }
+
+  @override
+  String toString() {
+    return 'PlayerOverallStatistics(player: $player, totalPlays: $totalPlays, totalWins: $totalWins, competitiveWinRate: $competitiveWinRate, coopWinRate: $coopWinRate, gamesByPlays: $gamesByPlays, rival: $rival, nemesis: $nemesis, buddies: $buddies)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PlayerOverallStatisticsImpl &&
+            (identical(other.player, player) || other.player == player) &&
+            (identical(other.totalPlays, totalPlays) ||
+                other.totalPlays == totalPlays) &&
+            (identical(other.totalWins, totalWins) ||
+                other.totalWins == totalWins) &&
+            (identical(other.competitiveWinRate, competitiveWinRate) ||
+                other.competitiveWinRate == competitiveWinRate) &&
+            (identical(other.coopWinRate, coopWinRate) ||
+                other.coopWinRate == coopWinRate) &&
+            const DeepCollectionEquality()
+                .equals(other._gamesByPlays, _gamesByPlays) &&
+            (identical(other.rival, rival) || other.rival == rival) &&
+            (identical(other.nemesis, nemesis) || other.nemesis == nemesis) &&
+            const DeepCollectionEquality().equals(other._buddies, _buddies));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      player,
+      totalPlays,
+      totalWins,
+      competitiveWinRate,
+      coopWinRate,
+      const DeepCollectionEquality().hash(_gamesByPlays),
+      rival,
+      nemesis,
+      const DeepCollectionEquality().hash(_buddies));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PlayerOverallStatisticsImplCopyWith<_$PlayerOverallStatisticsImpl>
+      get copyWith => __$$PlayerOverallStatisticsImplCopyWithImpl<
+          _$PlayerOverallStatisticsImpl>(this, _$identity);
+}
+
+abstract class _PlayerOverallStatistics extends PlayerOverallStatistics {
+  const factory _PlayerOverallStatistics(
+      {required final Player player,
+      required final int totalPlays,
+      required final int totalWins,
+      final double? competitiveWinRate,
+      final double? coopWinRate,
+      final List<GamePlaysCount> gamesByPlays,
+      final HeadToHeadRecord? rival,
+      final HeadToHeadRecord? nemesis,
+      final List<BuddyRecord> buddies}) = _$PlayerOverallStatisticsImpl;
+  const _PlayerOverallStatistics._() : super._();
+
+  @override
+  Player get player;
+  @override
+  int get totalPlays;
+  @override
+  int get totalWins;
+  @override
+  double? get competitiveWinRate;
+  @override
+  double? get coopWinRate;
+  @override
+  List<GamePlaysCount> get gamesByPlays;
+  @override
+  HeadToHeadRecord? get rival;
+  @override
+  HeadToHeadRecord? get nemesis;
+  @override
+  List<BuddyRecord> get buddies;
+  @override
+  @JsonKey(ignore: true)
+  _$$PlayerOverallStatisticsImplCopyWith<_$PlayerOverallStatisticsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$GamePlaysCount {
+  String get boardGameId => throw _privateConstructorUsedError;
+  String get boardGameName => throw _privateConstructorUsedError;
+  String? get boardGameImageUrl => throw _privateConstructorUsedError;
+  int get playCount => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $GamePlaysCountCopyWith<GamePlaysCount> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamePlaysCountCopyWith<$Res> {
+  factory $GamePlaysCountCopyWith(
+          GamePlaysCount value, $Res Function(GamePlaysCount) then) =
+      _$GamePlaysCountCopyWithImpl<$Res, GamePlaysCount>;
+  @useResult
+  $Res call(
+      {String boardGameId,
+      String boardGameName,
+      String? boardGameImageUrl,
+      int playCount});
+}
+
+/// @nodoc
+class _$GamePlaysCountCopyWithImpl<$Res, $Val extends GamePlaysCount>
+    implements $GamePlaysCountCopyWith<$Res> {
+  _$GamePlaysCountCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardGameId = null,
+    Object? boardGameName = null,
+    Object? boardGameImageUrl = freezed,
+    Object? playCount = null,
+  }) {
+    return _then(_value.copyWith(
+      boardGameId: null == boardGameId
+          ? _value.boardGameId
+          : boardGameId // ignore: cast_nullable_to_non_nullable
+              as String,
+      boardGameName: null == boardGameName
+          ? _value.boardGameName
+          : boardGameName // ignore: cast_nullable_to_non_nullable
+              as String,
+      boardGameImageUrl: freezed == boardGameImageUrl
+          ? _value.boardGameImageUrl
+          : boardGameImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GamePlaysCountImplCopyWith<$Res>
+    implements $GamePlaysCountCopyWith<$Res> {
+  factory _$$GamePlaysCountImplCopyWith(_$GamePlaysCountImpl value,
+          $Res Function(_$GamePlaysCountImpl) then) =
+      __$$GamePlaysCountImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String boardGameId,
+      String boardGameName,
+      String? boardGameImageUrl,
+      int playCount});
+}
+
+/// @nodoc
+class __$$GamePlaysCountImplCopyWithImpl<$Res>
+    extends _$GamePlaysCountCopyWithImpl<$Res, _$GamePlaysCountImpl>
+    implements _$$GamePlaysCountImplCopyWith<$Res> {
+  __$$GamePlaysCountImplCopyWithImpl(
+      _$GamePlaysCountImpl _value, $Res Function(_$GamePlaysCountImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardGameId = null,
+    Object? boardGameName = null,
+    Object? boardGameImageUrl = freezed,
+    Object? playCount = null,
+  }) {
+    return _then(_$GamePlaysCountImpl(
+      boardGameId: null == boardGameId
+          ? _value.boardGameId
+          : boardGameId // ignore: cast_nullable_to_non_nullable
+              as String,
+      boardGameName: null == boardGameName
+          ? _value.boardGameName
+          : boardGameName // ignore: cast_nullable_to_non_nullable
+              as String,
+      boardGameImageUrl: freezed == boardGameImageUrl
+          ? _value.boardGameImageUrl
+          : boardGameImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$GamePlaysCountImpl implements _GamePlaysCount {
+  const _$GamePlaysCountImpl(
+      {required this.boardGameId,
+      required this.boardGameName,
+      this.boardGameImageUrl,
+      required this.playCount});
+
+  @override
+  final String boardGameId;
+  @override
+  final String boardGameName;
+  @override
+  final String? boardGameImageUrl;
+  @override
+  final int playCount;
+
+  @override
+  String toString() {
+    return 'GamePlaysCount(boardGameId: $boardGameId, boardGameName: $boardGameName, boardGameImageUrl: $boardGameImageUrl, playCount: $playCount)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GamePlaysCountImpl &&
+            (identical(other.boardGameId, boardGameId) ||
+                other.boardGameId == boardGameId) &&
+            (identical(other.boardGameName, boardGameName) ||
+                other.boardGameName == boardGameName) &&
+            (identical(other.boardGameImageUrl, boardGameImageUrl) ||
+                other.boardGameImageUrl == boardGameImageUrl) &&
+            (identical(other.playCount, playCount) ||
+                other.playCount == playCount));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, boardGameId, boardGameName, boardGameImageUrl, playCount);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GamePlaysCountImplCopyWith<_$GamePlaysCountImpl> get copyWith =>
+      __$$GamePlaysCountImplCopyWithImpl<_$GamePlaysCountImpl>(
+          this, _$identity);
+}
+
+abstract class _GamePlaysCount implements GamePlaysCount {
+  const factory _GamePlaysCount(
+      {required final String boardGameId,
+      required final String boardGameName,
+      final String? boardGameImageUrl,
+      required final int playCount}) = _$GamePlaysCountImpl;
+
+  @override
+  String get boardGameId;
+  @override
+  String get boardGameName;
+  @override
+  String? get boardGameImageUrl;
+  @override
+  int get playCount;
+  @override
+  @JsonKey(ignore: true)
+  _$$GamePlaysCountImplCopyWith<_$GamePlaysCountImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$HeadToHeadRecord {
+  Player get opponent => throw _privateConstructorUsedError;
+  int get wins => throw _privateConstructorUsedError;
+  int get losses => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $HeadToHeadRecordCopyWith<HeadToHeadRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HeadToHeadRecordCopyWith<$Res> {
+  factory $HeadToHeadRecordCopyWith(
+          HeadToHeadRecord value, $Res Function(HeadToHeadRecord) then) =
+      _$HeadToHeadRecordCopyWithImpl<$Res, HeadToHeadRecord>;
+  @useResult
+  $Res call({Player opponent, int wins, int losses});
+
+  $PlayerCopyWith<$Res> get opponent;
+}
+
+/// @nodoc
+class _$HeadToHeadRecordCopyWithImpl<$Res, $Val extends HeadToHeadRecord>
+    implements $HeadToHeadRecordCopyWith<$Res> {
+  _$HeadToHeadRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? opponent = null,
+    Object? wins = null,
+    Object? losses = null,
+  }) {
+    return _then(_value.copyWith(
+      opponent: null == opponent
+          ? _value.opponent
+          : opponent // ignore: cast_nullable_to_non_nullable
+              as Player,
+      wins: null == wins
+          ? _value.wins
+          : wins // ignore: cast_nullable_to_non_nullable
+              as int,
+      losses: null == losses
+          ? _value.losses
+          : losses // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerCopyWith<$Res> get opponent {
+    return $PlayerCopyWith<$Res>(_value.opponent, (value) {
+      return _then(_value.copyWith(opponent: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$HeadToHeadRecordImplCopyWith<$Res>
+    implements $HeadToHeadRecordCopyWith<$Res> {
+  factory _$$HeadToHeadRecordImplCopyWith(_$HeadToHeadRecordImpl value,
+          $Res Function(_$HeadToHeadRecordImpl) then) =
+      __$$HeadToHeadRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Player opponent, int wins, int losses});
+
+  @override
+  $PlayerCopyWith<$Res> get opponent;
+}
+
+/// @nodoc
+class __$$HeadToHeadRecordImplCopyWithImpl<$Res>
+    extends _$HeadToHeadRecordCopyWithImpl<$Res, _$HeadToHeadRecordImpl>
+    implements _$$HeadToHeadRecordImplCopyWith<$Res> {
+  __$$HeadToHeadRecordImplCopyWithImpl(_$HeadToHeadRecordImpl _value,
+      $Res Function(_$HeadToHeadRecordImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? opponent = null,
+    Object? wins = null,
+    Object? losses = null,
+  }) {
+    return _then(_$HeadToHeadRecordImpl(
+      opponent: null == opponent
+          ? _value.opponent
+          : opponent // ignore: cast_nullable_to_non_nullable
+              as Player,
+      wins: null == wins
+          ? _value.wins
+          : wins // ignore: cast_nullable_to_non_nullable
+              as int,
+      losses: null == losses
+          ? _value.losses
+          : losses // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HeadToHeadRecordImpl implements _HeadToHeadRecord {
+  const _$HeadToHeadRecordImpl(
+      {required this.opponent, required this.wins, required this.losses});
+
+  @override
+  final Player opponent;
+  @override
+  final int wins;
+  @override
+  final int losses;
+
+  @override
+  String toString() {
+    return 'HeadToHeadRecord(opponent: $opponent, wins: $wins, losses: $losses)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HeadToHeadRecordImpl &&
+            (identical(other.opponent, opponent) ||
+                other.opponent == opponent) &&
+            (identical(other.wins, wins) || other.wins == wins) &&
+            (identical(other.losses, losses) || other.losses == losses));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, opponent, wins, losses);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HeadToHeadRecordImplCopyWith<_$HeadToHeadRecordImpl> get copyWith =>
+      __$$HeadToHeadRecordImplCopyWithImpl<_$HeadToHeadRecordImpl>(
+          this, _$identity);
+}
+
+abstract class _HeadToHeadRecord implements HeadToHeadRecord {
+  const factory _HeadToHeadRecord(
+      {required final Player opponent,
+      required final int wins,
+      required final int losses}) = _$HeadToHeadRecordImpl;
+
+  @override
+  Player get opponent;
+  @override
+  int get wins;
+  @override
+  int get losses;
+  @override
+  @JsonKey(ignore: true)
+  _$$HeadToHeadRecordImplCopyWith<_$HeadToHeadRecordImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$BuddyRecord {
+  Player get buddy => throw _privateConstructorUsedError;
+  int get sharedPlaysCount => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BuddyRecordCopyWith<BuddyRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BuddyRecordCopyWith<$Res> {
+  factory $BuddyRecordCopyWith(
+          BuddyRecord value, $Res Function(BuddyRecord) then) =
+      _$BuddyRecordCopyWithImpl<$Res, BuddyRecord>;
+  @useResult
+  $Res call({Player buddy, int sharedPlaysCount});
+
+  $PlayerCopyWith<$Res> get buddy;
+}
+
+/// @nodoc
+class _$BuddyRecordCopyWithImpl<$Res, $Val extends BuddyRecord>
+    implements $BuddyRecordCopyWith<$Res> {
+  _$BuddyRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? buddy = null,
+    Object? sharedPlaysCount = null,
+  }) {
+    return _then(_value.copyWith(
+      buddy: null == buddy
+          ? _value.buddy
+          : buddy // ignore: cast_nullable_to_non_nullable
+              as Player,
+      sharedPlaysCount: null == sharedPlaysCount
+          ? _value.sharedPlaysCount
+          : sharedPlaysCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerCopyWith<$Res> get buddy {
+    return $PlayerCopyWith<$Res>(_value.buddy, (value) {
+      return _then(_value.copyWith(buddy: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$BuddyRecordImplCopyWith<$Res>
+    implements $BuddyRecordCopyWith<$Res> {
+  factory _$$BuddyRecordImplCopyWith(
+          _$BuddyRecordImpl value, $Res Function(_$BuddyRecordImpl) then) =
+      __$$BuddyRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Player buddy, int sharedPlaysCount});
+
+  @override
+  $PlayerCopyWith<$Res> get buddy;
+}
+
+/// @nodoc
+class __$$BuddyRecordImplCopyWithImpl<$Res>
+    extends _$BuddyRecordCopyWithImpl<$Res, _$BuddyRecordImpl>
+    implements _$$BuddyRecordImplCopyWith<$Res> {
+  __$$BuddyRecordImplCopyWithImpl(
+      _$BuddyRecordImpl _value, $Res Function(_$BuddyRecordImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? buddy = null,
+    Object? sharedPlaysCount = null,
+  }) {
+    return _then(_$BuddyRecordImpl(
+      buddy: null == buddy
+          ? _value.buddy
+          : buddy // ignore: cast_nullable_to_non_nullable
+              as Player,
+      sharedPlaysCount: null == sharedPlaysCount
+          ? _value.sharedPlaysCount
+          : sharedPlaysCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BuddyRecordImpl implements _BuddyRecord {
+  const _$BuddyRecordImpl(
+      {required this.buddy, required this.sharedPlaysCount});
+
+  @override
+  final Player buddy;
+  @override
+  final int sharedPlaysCount;
+
+  @override
+  String toString() {
+    return 'BuddyRecord(buddy: $buddy, sharedPlaysCount: $sharedPlaysCount)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BuddyRecordImpl &&
+            (identical(other.buddy, buddy) || other.buddy == buddy) &&
+            (identical(other.sharedPlaysCount, sharedPlaysCount) ||
+                other.sharedPlaysCount == sharedPlaysCount));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, buddy, sharedPlaysCount);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BuddyRecordImplCopyWith<_$BuddyRecordImpl> get copyWith =>
+      __$$BuddyRecordImplCopyWithImpl<_$BuddyRecordImpl>(this, _$identity);
+}
+
+abstract class _BuddyRecord implements BuddyRecord {
+  const factory _BuddyRecord(
+      {required final Player buddy,
+      required final int sharedPlaysCount}) = _$BuddyRecordImpl;
+
+  @override
+  Player get buddy;
+  @override
+  int get sharedPlaysCount;
+  @override
+  @JsonKey(ignore: true)
+  _$$BuddyRecordImplCopyWith<_$BuddyRecordImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/board_games_companion/lib/pages/player_statistics/player_statistics_page.dart
+++ b/board_games_companion/lib/pages/player_statistics/player_statistics_page.dart
@@ -1,0 +1,511 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../common/app_colors.dart';
+import '../../common/app_styles.dart';
+import '../../common/app_text.dart';
+import '../../common/app_theme.dart';
+import '../../common/dimensions.dart';
+import '../../models/hive/player.dart';
+import '../../models/navigation/board_game_details_page_arguments.dart';
+import '../../models/navigation/player_page_arguments.dart';
+import '../../models/navigation/player_statistics_page_arguments.dart';
+import '../../models/player_overall_statistics.dart';
+import '../../widgets/board_games/board_game_image.dart';
+import '../../widgets/common/empty_page_information_panel.dart';
+import '../../widgets/common/loading_indicator_widget.dart';
+import '../../widgets/common/page_container.dart';
+import '../../widgets/common/slivers/bgc_sliver_section_wrapper.dart';
+import '../../widgets/common/slivers/bgc_sliver_title_header_delegate.dart';
+import '../../widgets/common/stats/vertical_statistics_item.dart';
+import '../../widgets/player/player_avatar.dart';
+import '../base_page_state.dart';
+import '../board_game_details/board_game_details_page.dart';
+import '../player/player_page.dart';
+import 'player_statistics_view_model.dart';
+import 'player_statistics_visual_state.dart';
+
+class PlayerStatisticsPage extends StatefulWidget {
+  const PlayerStatisticsPage({
+    required this.viewModel,
+    super.key,
+  });
+
+  static const String pageRoute = '/playerStatistics';
+
+  final PlayerStatisticsViewModel viewModel;
+
+  @override
+  PlayerStatisticsPageState createState() => PlayerStatisticsPageState();
+}
+
+class PlayerStatisticsPageState extends BasePageState<PlayerStatisticsPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    widget.viewModel.loadPlayerStatistics();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: Observer(
+            builder: (_) => Text(
+              widget.viewModel.player?.name ?? '',
+              style: AppTheme.titleTextStyle,
+            ),
+          ),
+          actions: [
+            Observer(
+              builder: (_) {
+                final player = widget.viewModel.player;
+                if (player == null) {
+                  return const SizedBox.shrink();
+                }
+
+                return IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => Navigator.pushNamed(
+                    context,
+                    PlayerPage.pageRoute,
+                    arguments: PlayerPageArguments(player: player),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        body: SafeArea(
+          child: PageContainer(
+            child: Observer(
+              builder: (_) {
+                return switch (widget.viewModel.visualState) {
+                  PlayerStatisticsLoading() => const LoadingIndicator(),
+                  PlayerStatisticsEmpty() => _EmptyState(viewModel: widget.viewModel),
+                  PlayerStatisticsLoaded(:final statistics) => _LoadedContent(
+                      viewModel: widget.viewModel,
+                      statistics: statistics,
+                    ),
+                  _ => const LoadingIndicator(),
+                };
+              },
+            ),
+          ),
+        ),
+      );
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.viewModel});
+
+  final PlayerStatisticsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: _Header(
+            player: viewModel.player,
+            isPlayerDeleted: viewModel.isPlayerDeleted,
+          ),
+        ),
+        const SliverFillRemaining(
+          hasScrollBody: false,
+          child: Center(
+            child: EmptyPageInformationPanel(
+              title: AppText.playerStatisticsPageNoPlaysTitle,
+              icon: Icon(
+                Icons.query_stats,
+                size: Dimensions.emptyPageTitleIconSize,
+                color: AppColors.primaryColor,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LoadedContent extends StatelessWidget {
+  const _LoadedContent({
+    required this.viewModel,
+    required this.statistics,
+  });
+
+  final PlayerStatisticsViewModel viewModel;
+  final PlayerOverallStatistics statistics;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: _Header(
+            player: viewModel.player,
+            isPlayerDeleted: viewModel.isPlayerDeleted,
+          ),
+        ),
+        SliverSectionWrapper(
+          child: _TotalsAndWinRates(statistics: statistics),
+        ),
+        if (statistics.gamesByPlays.isNotEmpty) ...[
+          SliverPersistentHeader(
+            delegate: BgcSliverTitleHeaderDelegate.title(
+              primaryTitle: AppText.playerStatisticsPageGamesSectionTitle,
+            ),
+          ),
+          SliverSectionWrapper(
+            child: _GamesSection(viewModel: viewModel),
+          ),
+        ],
+        if (statistics.rival != null) ...[
+          SliverPersistentHeader(
+            delegate: BgcSliverTitleHeaderDelegate.title(
+              primaryTitle: AppText.playerStatisticsPageRivalSectionTitle,
+            ),
+          ),
+          SliverSectionWrapper(
+            child: _HeadToHeadRow(record: statistics.rival!),
+          ),
+        ],
+        if (statistics.nemesis != null) ...[
+          SliverPersistentHeader(
+            delegate: BgcSliverTitleHeaderDelegate.title(
+              primaryTitle: AppText.playerStatisticsPageNemesisSectionTitle,
+            ),
+          ),
+          SliverSectionWrapper(
+            child: _HeadToHeadRow(record: statistics.nemesis!),
+          ),
+        ],
+        if (statistics.buddies.isNotEmpty) ...[
+          SliverPersistentHeader(
+            delegate: BgcSliverTitleHeaderDelegate.title(
+              primaryTitle: AppText.playerStatisticsPageBuddiesSectionTitle,
+            ),
+          ),
+          SliverSectionWrapper(
+            child: _BuddiesSection(buddies: statistics.buddies),
+          ),
+        ],
+        const SliverPadding(
+          padding: EdgeInsets.only(
+            bottom: Dimensions.standardSpacing + Dimensions.bottomTabTopHeight,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.player,
+    required this.isPlayerDeleted,
+  });
+
+  final Player? player;
+  final bool isPlayerDeleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (isPlayerDeleted) const _DeletedPlayerBanner(),
+        Padding(
+          padding: const EdgeInsets.all(Dimensions.standardSpacing),
+          child: Center(
+            child: SizedBox(
+              width: Dimensions.defaultPlayerAvatarSize,
+              height: Dimensions.defaultPlayerAvatarSize,
+              child: PlayerAvatar(
+                player: player,
+                avatarImageSize: const Size(
+                  Dimensions.defaultPlayerAvatarSize,
+                  Dimensions.defaultPlayerAvatarSize,
+                ),
+                useHeroAnimation: false,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DeletedPlayerBanner extends StatelessWidget {
+  const _DeletedPlayerBanner();
+
+  @override
+  Widget build(BuildContext context) => Row(
+        children: [
+          Expanded(
+            child: SizedBox(
+              height: 40,
+              child: Container(
+                color: AppColors.redColor,
+                child: const Center(
+                  child: Text(AppText.playerPagePlayerDeletedBanner),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+}
+
+class _TotalsAndWinRates extends StatelessWidget {
+  const _TotalsAndWinRates({required this.statistics});
+
+  final PlayerOverallStatistics statistics;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: VerticalStatisticsItem.withMaterialIcon(
+                text: statistics.totalPlays.toString(),
+                icon: Icons.casino,
+                iconColor: AppColors.playedGamesStatColor,
+                subtitle: AppText.playerStatisticsPageTotalPlays,
+              ),
+            ),
+            Expanded(
+              child: VerticalStatisticsItem.withFontAwesomeIcon(
+                text: statistics.totalWins.toString(),
+                icon: FontAwesomeIcons.trophy,
+                iconColor: AppColors.totalWinsStatColor,
+                subtitle: AppText.playerStatisticsPageTotalWins,
+              ),
+            ),
+          ],
+        ),
+        if (statistics.competitiveWinRate != null || statistics.coopWinRate != null) ...[
+          const SizedBox(height: Dimensions.doubleStandardSpacing),
+          Row(
+            children: [
+              if (statistics.competitiveWinRate != null)
+                Expanded(
+                  child: VerticalStatisticsItem.withMaterialIcon(
+                    text: '${(statistics.competitiveWinRate! * 100).toStringAsFixed(0)}%',
+                    icon: Icons.leaderboard,
+                    iconColor: AppColors.averageScoreStatColor,
+                    subtitle: AppText.playerStatisticsPageCompetitiveWinRate,
+                  ),
+                ),
+              if (statistics.coopWinRate != null)
+                Expanded(
+                  child: VerticalStatisticsItem.withMaterialIcon(
+                    text: '${(statistics.coopWinRate! * 100).toStringAsFixed(0)}%',
+                    icon: Icons.percent,
+                    iconColor: AppColors.averagePlayerCountStatColor,
+                    subtitle: AppText.playerStatisticsPageCoopWinRate,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _GamesSection extends StatelessWidget {
+  const _GamesSection({required this.viewModel});
+
+  final PlayerStatisticsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Observer(
+      builder: (_) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final game in viewModel.displayedGames) ...[
+              _GameRow(game: game),
+              const SizedBox(height: Dimensions.standardSpacing),
+            ],
+            if (viewModel.canExpandGames)
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: viewModel.toggleGamesExpansion,
+                  child: Text(
+                    viewModel.isGamesListExpanded
+                        ? AppText.playerStatisticsPageGamesShowLess
+                        : AppText.playerStatisticsPageGamesShowMore,
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _GameRow extends StatelessWidget {
+  const _GameRow({required this.game});
+
+  final GamePlaysCount game;
+
+  static const double _imageSize = 50;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppStyles.defaultCornerRadius),
+        onTap: () => Navigator.pushNamed(
+          context,
+          BoardGamesDetailsPage.pageRoute,
+          arguments: BoardGameDetailsPageArguments(
+            boardGameId: game.boardGameId,
+            navigatingFromType: PlayerStatisticsPage,
+            boardGameImageHeroId: game.boardGameId,
+          ),
+        ),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(AppStyles.defaultCornerRadius),
+              child: SizedBox(
+                width: _imageSize,
+                height: _imageSize,
+                child: BoardGameImage(
+                  id: game.boardGameId,
+                  url: game.boardGameImageUrl,
+                  minImageHeight: _imageSize,
+                ),
+              ),
+            ),
+            const SizedBox(width: Dimensions.standardSpacing),
+            Expanded(
+              child: Text(
+                game.boardGameName,
+                style: AppTheme.theme.textTheme.bodyMedium,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: Dimensions.standardSpacing),
+            VerticalStatisticsItem.withMaterialIcon(
+              text: game.playCount.toString(),
+              icon: Icons.casino,
+              iconColor: AppColors.playedGamesStatColor,
+              iconSize: Dimensions.defaultButtonIconSize,
+              textStyle: const TextStyle(fontSize: Dimensions.mediumFontSize),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeadToHeadRow extends StatelessWidget {
+  const _HeadToHeadRow({required this.record});
+
+  final HeadToHeadRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    return _OpponentRow(
+      player: record.opponent,
+      trailing: Text(
+        '${record.wins}–${record.losses}',
+        style: const TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: Dimensions.largeFontSize,
+        ),
+      ),
+    );
+  }
+}
+
+class _BuddiesSection extends StatelessWidget {
+  const _BuddiesSection({required this.buddies});
+
+  final List<BuddyRecord> buddies;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final buddy in buddies) ...[
+          _OpponentRow(
+            player: buddy.buddy,
+            trailing: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  buddy.sharedPlaysCount.toString(),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: Dimensions.largeFontSize,
+                  ),
+                ),
+                Text(
+                  AppText.playerStatisticsPageBuddiesSharedPlays,
+                  style: AppTheme.theme.textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: Dimensions.standardSpacing),
+        ],
+      ],
+    );
+  }
+}
+
+class _OpponentRow extends StatelessWidget {
+  const _OpponentRow({
+    required this.player,
+    required this.trailing,
+  });
+
+  final Player player;
+  final Widget trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppStyles.defaultCornerRadius),
+        onTap: () => Navigator.pushNamed(
+          context,
+          PlayerStatisticsPage.pageRoute,
+          arguments: PlayerStatisticsPageArguments(player: player),
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: Dimensions.smallPlayerAvatarSize.width,
+              height: Dimensions.smallPlayerAvatarSize.height,
+              child: PlayerAvatar(
+                player: player,
+                avatarImageSize: Dimensions.smallPlayerAvatarSize,
+                useHeroAnimation: false,
+              ),
+            ),
+            const Spacer(),
+            trailing,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/board_games_companion/lib/pages/player_statistics/player_statistics_view_model.dart
+++ b/board_games_companion/lib/pages/player_statistics/player_statistics_view_model.dart
@@ -1,0 +1,103 @@
+// ignore_for_file: library_private_types_in_public_api
+
+import 'package:collection/collection.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:injectable/injectable.dart';
+import 'package:mobx/mobx.dart';
+
+import '../../models/hive/player.dart';
+import '../../models/player_overall_statistics.dart';
+import '../../services/player_statistics_service.dart';
+import '../../stores/board_games_store.dart';
+import '../../stores/players_store.dart';
+import '../../stores/playthroughs_store.dart';
+import '../../stores/scores_store.dart';
+import 'player_statistics_visual_state.dart';
+
+part 'player_statistics_view_model.g.dart';
+
+@injectable
+class PlayerStatisticsViewModel = _PlayerStatisticsViewModel with _$PlayerStatisticsViewModel;
+
+abstract class _PlayerStatisticsViewModel with Store {
+  _PlayerStatisticsViewModel(
+    this._playerStatisticsService,
+    this._playersStore,
+    this._playthroughsStore,
+    this._scoresStore,
+    this._boardGamesStore,
+  );
+
+  static const int gamesCollapsedCount = 5;
+
+  final PlayerStatisticsService _playerStatisticsService;
+  final PlayersStore _playersStore;
+  final PlaythroughsStore _playthroughsStore;
+  final ScoresStore _scoresStore;
+  final BoardGamesStore _boardGamesStore;
+
+  @observable
+  Player? player;
+
+  @observable
+  PlayerStatisticsVisualState visualState = const PlayerStatisticsVisualState.loading();
+
+  @observable
+  PlayerOverallStatistics? statistics;
+
+  @observable
+  bool isGamesListExpanded = false;
+
+  @observable
+  ObservableFuture<void>? futureLoadStatistics;
+
+  @computed
+  bool get isPlayerDeleted => player?.isDeleted ?? false;
+
+  @computed
+  List<GamePlaysCount> get displayedGames => statistics == null
+      ? <GamePlaysCount>[]
+      : (isGamesListExpanded
+          ? statistics!.gamesByPlays
+          : statistics!.gamesByPlays.take(gamesCollapsedCount).toList());
+
+  @computed
+  bool get canExpandGames => (statistics?.gamesByPlays.length ?? 0) > gamesCollapsedCount;
+
+  @action
+  void setPlayer(Player? player) {
+    this.player = player;
+  }
+
+  @action
+  void toggleGamesExpansion() => isGamesListExpanded = !isGamesListExpanded;
+
+  @action
+  void loadPlayerStatistics() =>
+      futureLoadStatistics = ObservableFuture<void>(_loadPlayerStatistics());
+
+  Future<void> _loadPlayerStatistics() async {
+    try {
+      visualState = const PlayerStatisticsVisualState.loading();
+
+      await Future.wait([
+        _playersStore.loadPlayers(),
+        _playthroughsStore.loadPlaythroughs(),
+        _scoresStore.loadScores(),
+        _boardGamesStore.loadBoardGames(),
+      ]);
+
+      player = _playersStore.players.firstWhereOrNull((p) => p.id == player?.id) ?? player;
+
+      final stats = _playerStatisticsService.retrievePlayerStatistics(player!.id);
+      statistics = stats;
+      visualState = stats.hasNoPlays
+          ? const PlayerStatisticsVisualState.empty()
+          : PlayerStatisticsVisualState.loaded(stats);
+    } catch (e, stack) {
+      FirebaseCrashlytics.instance.recordError(e, stack);
+      // Fail closed to the empty state rather than leaving the page stuck on a spinner.
+      visualState = const PlayerStatisticsVisualState.empty();
+    }
+  }
+}

--- a/board_games_companion/lib/pages/player_statistics/player_statistics_view_model.g.dart
+++ b/board_games_companion/lib/pages/player_statistics/player_statistics_view_model.g.dart
@@ -1,0 +1,165 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'player_statistics_view_model.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
+
+mixin _$PlayerStatisticsViewModel on _PlayerStatisticsViewModel, Store {
+  Computed<bool>? _$isPlayerDeletedComputed;
+
+  @override
+  bool get isPlayerDeleted =>
+      (_$isPlayerDeletedComputed ??= Computed<bool>(() => super.isPlayerDeleted,
+              name: '_PlayerStatisticsViewModel.isPlayerDeleted'))
+          .value;
+  Computed<List<GamePlaysCount>>? _$displayedGamesComputed;
+
+  @override
+  List<GamePlaysCount> get displayedGames => (_$displayedGamesComputed ??=
+          Computed<List<GamePlaysCount>>(() => super.displayedGames,
+              name: '_PlayerStatisticsViewModel.displayedGames'))
+      .value;
+  Computed<bool>? _$canExpandGamesComputed;
+
+  @override
+  bool get canExpandGames =>
+      (_$canExpandGamesComputed ??= Computed<bool>(() => super.canExpandGames,
+              name: '_PlayerStatisticsViewModel.canExpandGames'))
+          .value;
+
+  late final _$playerAtom =
+      Atom(name: '_PlayerStatisticsViewModel.player', context: context);
+
+  @override
+  Player? get player {
+    _$playerAtom.reportRead();
+    return super.player;
+  }
+
+  @override
+  set player(Player? value) {
+    _$playerAtom.reportWrite(value, super.player, () {
+      super.player = value;
+    });
+  }
+
+  late final _$visualStateAtom =
+      Atom(name: '_PlayerStatisticsViewModel.visualState', context: context);
+
+  @override
+  PlayerStatisticsVisualState get visualState {
+    _$visualStateAtom.reportRead();
+    return super.visualState;
+  }
+
+  @override
+  set visualState(PlayerStatisticsVisualState value) {
+    _$visualStateAtom.reportWrite(value, super.visualState, () {
+      super.visualState = value;
+    });
+  }
+
+  late final _$statisticsAtom =
+      Atom(name: '_PlayerStatisticsViewModel.statistics', context: context);
+
+  @override
+  PlayerOverallStatistics? get statistics {
+    _$statisticsAtom.reportRead();
+    return super.statistics;
+  }
+
+  @override
+  set statistics(PlayerOverallStatistics? value) {
+    _$statisticsAtom.reportWrite(value, super.statistics, () {
+      super.statistics = value;
+    });
+  }
+
+  late final _$isGamesListExpandedAtom = Atom(
+      name: '_PlayerStatisticsViewModel.isGamesListExpanded', context: context);
+
+  @override
+  bool get isGamesListExpanded {
+    _$isGamesListExpandedAtom.reportRead();
+    return super.isGamesListExpanded;
+  }
+
+  @override
+  set isGamesListExpanded(bool value) {
+    _$isGamesListExpandedAtom.reportWrite(value, super.isGamesListExpanded, () {
+      super.isGamesListExpanded = value;
+    });
+  }
+
+  late final _$futureLoadStatisticsAtom = Atom(
+      name: '_PlayerStatisticsViewModel.futureLoadStatistics',
+      context: context);
+
+  @override
+  ObservableFuture<void>? get futureLoadStatistics {
+    _$futureLoadStatisticsAtom.reportRead();
+    return super.futureLoadStatistics;
+  }
+
+  @override
+  set futureLoadStatistics(ObservableFuture<void>? value) {
+    _$futureLoadStatisticsAtom.reportWrite(value, super.futureLoadStatistics,
+        () {
+      super.futureLoadStatistics = value;
+    });
+  }
+
+  late final _$_PlayerStatisticsViewModelActionController =
+      ActionController(name: '_PlayerStatisticsViewModel', context: context);
+
+  @override
+  void setPlayer(Player? player) {
+    final _$actionInfo = _$_PlayerStatisticsViewModelActionController
+        .startAction(name: '_PlayerStatisticsViewModel.setPlayer');
+    try {
+      return super.setPlayer(player);
+    } finally {
+      _$_PlayerStatisticsViewModelActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void toggleGamesExpansion() {
+    final _$actionInfo = _$_PlayerStatisticsViewModelActionController
+        .startAction(name: '_PlayerStatisticsViewModel.toggleGamesExpansion');
+    try {
+      return super.toggleGamesExpansion();
+    } finally {
+      _$_PlayerStatisticsViewModelActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void loadPlayerStatistics() {
+    final _$actionInfo = _$_PlayerStatisticsViewModelActionController
+        .startAction(name: '_PlayerStatisticsViewModel.loadPlayerStatistics');
+    try {
+      return super.loadPlayerStatistics();
+    } finally {
+      _$_PlayerStatisticsViewModelActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  String toString() {
+    return '''
+player: ${player},
+visualState: ${visualState},
+statistics: ${statistics},
+isGamesListExpanded: ${isGamesListExpanded},
+futureLoadStatistics: ${futureLoadStatistics},
+isPlayerDeleted: ${isPlayerDeleted},
+displayedGames: ${displayedGames},
+canExpandGames: ${canExpandGames}
+    ''';
+  }
+}

--- a/board_games_companion/lib/pages/player_statistics/player_statistics_visual_state.dart
+++ b/board_games_companion/lib/pages/player_statistics/player_statistics_visual_state.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../models/player_overall_statistics.dart';
+
+part 'player_statistics_visual_state.freezed.dart';
+
+@freezed
+class PlayerStatisticsVisualState with _$PlayerStatisticsVisualState {
+  const factory PlayerStatisticsVisualState.loading() = PlayerStatisticsLoading;
+  const factory PlayerStatisticsVisualState.empty() = PlayerStatisticsEmpty;
+  const factory PlayerStatisticsVisualState.loaded(PlayerOverallStatistics statistics) =
+      PlayerStatisticsLoaded;
+}

--- a/board_games_companion/lib/pages/player_statistics/player_statistics_visual_state.freezed.dart
+++ b/board_games_companion/lib/pages/player_statistics/player_statistics_visual_state.freezed.dart
@@ -1,0 +1,462 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'player_statistics_visual_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$PlayerStatisticsVisualState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() loading,
+    required TResult Function() empty,
+    required TResult Function(PlayerOverallStatistics statistics) loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? loading,
+    TResult? Function()? empty,
+    TResult? Function(PlayerOverallStatistics statistics)? loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? loading,
+    TResult Function()? empty,
+    TResult Function(PlayerOverallStatistics statistics)? loaded,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PlayerStatisticsLoading value) loading,
+    required TResult Function(PlayerStatisticsEmpty value) empty,
+    required TResult Function(PlayerStatisticsLoaded value) loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PlayerStatisticsLoading value)? loading,
+    TResult? Function(PlayerStatisticsEmpty value)? empty,
+    TResult? Function(PlayerStatisticsLoaded value)? loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PlayerStatisticsLoading value)? loading,
+    TResult Function(PlayerStatisticsEmpty value)? empty,
+    TResult Function(PlayerStatisticsLoaded value)? loaded,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PlayerStatisticsVisualStateCopyWith<$Res> {
+  factory $PlayerStatisticsVisualStateCopyWith(
+          PlayerStatisticsVisualState value,
+          $Res Function(PlayerStatisticsVisualState) then) =
+      _$PlayerStatisticsVisualStateCopyWithImpl<$Res,
+          PlayerStatisticsVisualState>;
+}
+
+/// @nodoc
+class _$PlayerStatisticsVisualStateCopyWithImpl<$Res,
+        $Val extends PlayerStatisticsVisualState>
+    implements $PlayerStatisticsVisualStateCopyWith<$Res> {
+  _$PlayerStatisticsVisualStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$PlayerStatisticsLoadingImplCopyWith<$Res> {
+  factory _$$PlayerStatisticsLoadingImplCopyWith(
+          _$PlayerStatisticsLoadingImpl value,
+          $Res Function(_$PlayerStatisticsLoadingImpl) then) =
+      __$$PlayerStatisticsLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$PlayerStatisticsLoadingImplCopyWithImpl<$Res>
+    extends _$PlayerStatisticsVisualStateCopyWithImpl<$Res,
+        _$PlayerStatisticsLoadingImpl>
+    implements _$$PlayerStatisticsLoadingImplCopyWith<$Res> {
+  __$$PlayerStatisticsLoadingImplCopyWithImpl(
+      _$PlayerStatisticsLoadingImpl _value,
+      $Res Function(_$PlayerStatisticsLoadingImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$PlayerStatisticsLoadingImpl implements PlayerStatisticsLoading {
+  const _$PlayerStatisticsLoadingImpl();
+
+  @override
+  String toString() {
+    return 'PlayerStatisticsVisualState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PlayerStatisticsLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() loading,
+    required TResult Function() empty,
+    required TResult Function(PlayerOverallStatistics statistics) loaded,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? loading,
+    TResult? Function()? empty,
+    TResult? Function(PlayerOverallStatistics statistics)? loaded,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? loading,
+    TResult Function()? empty,
+    TResult Function(PlayerOverallStatistics statistics)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PlayerStatisticsLoading value) loading,
+    required TResult Function(PlayerStatisticsEmpty value) empty,
+    required TResult Function(PlayerStatisticsLoaded value) loaded,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PlayerStatisticsLoading value)? loading,
+    TResult? Function(PlayerStatisticsEmpty value)? empty,
+    TResult? Function(PlayerStatisticsLoaded value)? loaded,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PlayerStatisticsLoading value)? loading,
+    TResult Function(PlayerStatisticsEmpty value)? empty,
+    TResult Function(PlayerStatisticsLoaded value)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PlayerStatisticsLoading implements PlayerStatisticsVisualState {
+  const factory PlayerStatisticsLoading() = _$PlayerStatisticsLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$PlayerStatisticsEmptyImplCopyWith<$Res> {
+  factory _$$PlayerStatisticsEmptyImplCopyWith(
+          _$PlayerStatisticsEmptyImpl value,
+          $Res Function(_$PlayerStatisticsEmptyImpl) then) =
+      __$$PlayerStatisticsEmptyImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$PlayerStatisticsEmptyImplCopyWithImpl<$Res>
+    extends _$PlayerStatisticsVisualStateCopyWithImpl<$Res,
+        _$PlayerStatisticsEmptyImpl>
+    implements _$$PlayerStatisticsEmptyImplCopyWith<$Res> {
+  __$$PlayerStatisticsEmptyImplCopyWithImpl(_$PlayerStatisticsEmptyImpl _value,
+      $Res Function(_$PlayerStatisticsEmptyImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$PlayerStatisticsEmptyImpl implements PlayerStatisticsEmpty {
+  const _$PlayerStatisticsEmptyImpl();
+
+  @override
+  String toString() {
+    return 'PlayerStatisticsVisualState.empty()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PlayerStatisticsEmptyImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() loading,
+    required TResult Function() empty,
+    required TResult Function(PlayerOverallStatistics statistics) loaded,
+  }) {
+    return empty();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? loading,
+    TResult? Function()? empty,
+    TResult? Function(PlayerOverallStatistics statistics)? loaded,
+  }) {
+    return empty?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? loading,
+    TResult Function()? empty,
+    TResult Function(PlayerOverallStatistics statistics)? loaded,
+    required TResult orElse(),
+  }) {
+    if (empty != null) {
+      return empty();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PlayerStatisticsLoading value) loading,
+    required TResult Function(PlayerStatisticsEmpty value) empty,
+    required TResult Function(PlayerStatisticsLoaded value) loaded,
+  }) {
+    return empty(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PlayerStatisticsLoading value)? loading,
+    TResult? Function(PlayerStatisticsEmpty value)? empty,
+    TResult? Function(PlayerStatisticsLoaded value)? loaded,
+  }) {
+    return empty?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PlayerStatisticsLoading value)? loading,
+    TResult Function(PlayerStatisticsEmpty value)? empty,
+    TResult Function(PlayerStatisticsLoaded value)? loaded,
+    required TResult orElse(),
+  }) {
+    if (empty != null) {
+      return empty(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PlayerStatisticsEmpty implements PlayerStatisticsVisualState {
+  const factory PlayerStatisticsEmpty() = _$PlayerStatisticsEmptyImpl;
+}
+
+/// @nodoc
+abstract class _$$PlayerStatisticsLoadedImplCopyWith<$Res> {
+  factory _$$PlayerStatisticsLoadedImplCopyWith(
+          _$PlayerStatisticsLoadedImpl value,
+          $Res Function(_$PlayerStatisticsLoadedImpl) then) =
+      __$$PlayerStatisticsLoadedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({PlayerOverallStatistics statistics});
+
+  $PlayerOverallStatisticsCopyWith<$Res> get statistics;
+}
+
+/// @nodoc
+class __$$PlayerStatisticsLoadedImplCopyWithImpl<$Res>
+    extends _$PlayerStatisticsVisualStateCopyWithImpl<$Res,
+        _$PlayerStatisticsLoadedImpl>
+    implements _$$PlayerStatisticsLoadedImplCopyWith<$Res> {
+  __$$PlayerStatisticsLoadedImplCopyWithImpl(
+      _$PlayerStatisticsLoadedImpl _value,
+      $Res Function(_$PlayerStatisticsLoadedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? statistics = null,
+  }) {
+    return _then(_$PlayerStatisticsLoadedImpl(
+      null == statistics
+          ? _value.statistics
+          : statistics // ignore: cast_nullable_to_non_nullable
+              as PlayerOverallStatistics,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerOverallStatisticsCopyWith<$Res> get statistics {
+    return $PlayerOverallStatisticsCopyWith<$Res>(_value.statistics, (value) {
+      return _then(_value.copyWith(statistics: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$PlayerStatisticsLoadedImpl implements PlayerStatisticsLoaded {
+  const _$PlayerStatisticsLoadedImpl(this.statistics);
+
+  @override
+  final PlayerOverallStatistics statistics;
+
+  @override
+  String toString() {
+    return 'PlayerStatisticsVisualState.loaded(statistics: $statistics)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PlayerStatisticsLoadedImpl &&
+            (identical(other.statistics, statistics) ||
+                other.statistics == statistics));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, statistics);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PlayerStatisticsLoadedImplCopyWith<_$PlayerStatisticsLoadedImpl>
+      get copyWith => __$$PlayerStatisticsLoadedImplCopyWithImpl<
+          _$PlayerStatisticsLoadedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() loading,
+    required TResult Function() empty,
+    required TResult Function(PlayerOverallStatistics statistics) loaded,
+  }) {
+    return loaded(statistics);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? loading,
+    TResult? Function()? empty,
+    TResult? Function(PlayerOverallStatistics statistics)? loaded,
+  }) {
+    return loaded?.call(statistics);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? loading,
+    TResult Function()? empty,
+    TResult Function(PlayerOverallStatistics statistics)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(statistics);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PlayerStatisticsLoading value) loading,
+    required TResult Function(PlayerStatisticsEmpty value) empty,
+    required TResult Function(PlayerStatisticsLoaded value) loaded,
+  }) {
+    return loaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PlayerStatisticsLoading value)? loading,
+    TResult? Function(PlayerStatisticsEmpty value)? empty,
+    TResult? Function(PlayerStatisticsLoaded value)? loaded,
+  }) {
+    return loaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PlayerStatisticsLoading value)? loading,
+    TResult Function(PlayerStatisticsEmpty value)? empty,
+    TResult Function(PlayerStatisticsLoaded value)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PlayerStatisticsLoaded implements PlayerStatisticsVisualState {
+  const factory PlayerStatisticsLoaded(
+      final PlayerOverallStatistics statistics) = _$PlayerStatisticsLoadedImpl;
+
+  PlayerOverallStatistics get statistics;
+  @JsonKey(ignore: true)
+  _$$PlayerStatisticsLoadedImplCopyWith<_$PlayerStatisticsLoadedImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/board_games_companion/lib/pages/players/players_page.dart
+++ b/board_games_companion/lib/pages/players/players_page.dart
@@ -14,6 +14,7 @@ import '../../common/app_theme.dart';
 import '../../common/dimensions.dart';
 import '../../models/hive/player.dart';
 import '../../models/navigation/player_page_arguments.dart';
+import '../../models/navigation/player_statistics_page_arguments.dart';
 import '../../widgets/common/default_icon.dart';
 import '../../widgets/common/elevated_icon_button.dart';
 import '../../widgets/common/generic_error_message_widget.dart';
@@ -23,6 +24,7 @@ import '../../widgets/elevated_container.dart';
 import '../../widgets/player/player_avatar.dart';
 import '../../widgets/player/player_image.dart';
 import '../player/player_page.dart';
+import '../player_statistics/player_statistics_page.dart';
 import 'players_view_model.dart';
 
 typedef PlayerTapped = void Function(Player player, bool isChecked);
@@ -148,8 +150,8 @@ class PlayersPageState extends State<PlayersPage> {
   Future<void> _navigateToPlayerPage(BuildContext context, Player player) async {
     await Navigator.pushNamed(
       context,
-      PlayerPage.pageRoute,
-      arguments: PlayerPageArguments(player: player),
+      PlayerStatisticsPage.pageRoute,
+      arguments: PlayerStatisticsPageArguments(player: player),
     );
   }
 

--- a/board_games_companion/lib/pages/playthroughs/playthroughs_statistics_page.dart
+++ b/board_games_companion/lib/pages/playthroughs/playthroughs_statistics_page.dart
@@ -20,6 +20,7 @@ import '../../extensions/int_extensions.dart';
 import '../../injectable.dart';
 import '../../models/board_game_statistics.dart';
 import '../../models/hive/player.dart';
+import '../../models/navigation/player_statistics_page_arguments.dart';
 import '../../models/player_statistics.dart';
 import '../../widgets/board_games/board_game_image.dart';
 import '../../widgets/common/empty_page_information_panel.dart';
@@ -31,6 +32,7 @@ import '../../widgets/common/stats/vertical_statistics_item.dart';
 import '../../widgets/player/player_avatar.dart';
 import '../../widgets/playthrough/calendar_card.dart';
 import '../../widgets/playthrough/player_score_rank_avatar.dart';
+import '../player_statistics/player_statistics_page.dart';
 import 'playthrough_statistics_view_model.dart';
 
 class PlaythroughStatistcsPage extends StatefulWidget {
@@ -364,6 +366,11 @@ class _PlayerStatsDetails extends StatelessWidget {
               player: player,
               useHeroAnimation: false,
               avatarImageSize: Dimensions.smallPlayerAvatarSize,
+              onTap: () => Navigator.pushNamed(
+                context,
+                PlayerStatisticsPage.pageRoute,
+                arguments: PlayerStatisticsPageArguments(player: player),
+              ),
             ),
           ),
           const Spacer(),

--- a/board_games_companion/lib/services/player_statistics_service.dart
+++ b/board_games_companion/lib/services/player_statistics_service.dart
@@ -1,0 +1,405 @@
+import 'package:injectable/injectable.dart';
+
+import '../common/enums/game_classification.dart';
+import '../common/enums/game_family.dart';
+import '../common/enums/playthrough_status.dart';
+import '../models/hive/board_game_details.dart';
+import '../models/hive/no_score_game_result.dart';
+import '../models/hive/player.dart';
+import '../models/hive/playthrough.dart';
+import '../models/hive/score.dart';
+import '../models/player_overall_statistics.dart';
+import '../stores/board_games_store.dart';
+import '../stores/players_store.dart';
+import '../stores/playthroughs_store.dart';
+import '../stores/scores_store.dart';
+
+/// Minimum number of shared competitive plays an opponent needs before they can be
+/// considered as a candidate for the subject player's rival/nemesis.
+const int _minimumSharedCompetitivePlaysForHeadToHead = 3;
+
+/// Maximum number of buddies returned in [PlayerOverallStatistics.buddies].
+const int _maxBuddies = 5;
+
+@injectable
+class PlayerStatisticsService {
+  PlayerStatisticsService(
+    this._playersStore,
+    this._playthroughsStore,
+    this._scoresStore,
+    this._boardGamesStore,
+  );
+
+  final PlayersStore _playersStore;
+  final PlaythroughsStore _playthroughsStore;
+  final ScoresStore _scoresStore;
+  final BoardGamesStore _boardGamesStore;
+
+  PlayerOverallStatistics retrievePlayerStatistics(String playerId) {
+    final player = _resolvePlayerById(playerId);
+
+    final validPlaythroughs = _playthroughsStore.playthroughs
+        .where((playthrough) =>
+            playthrough.status == PlaythroughStatus.Finished &&
+            playthrough.isDeleted != true &&
+            playthrough.playerIds.contains(playerId))
+        .toList();
+
+    // Group the scores by playthrough once so the per-playthrough loop below does not
+    // re-scan the whole scores collection for every play.
+    final scoresByPlaythroughId = <String, List<Score>>{};
+    for (final score in _scoresStore.scores) {
+      final scorePlaythroughId = score.playthroughId;
+      if (scorePlaythroughId == null) {
+        continue;
+      }
+      (scoresByPlaythroughId[scorePlaythroughId] ??= <Score>[]).add(score);
+    }
+
+    // Reading the computed map once avoids rebuilding it on every playthrough.
+    final boardGamesById = _boardGamesStore.allBoardGamesMap;
+
+    final gamesByPlays = _retrieveGamesByPlays(validPlaythroughs, boardGamesById);
+    final buddies = _retrieveBuddies(playerId, validPlaythroughs);
+
+    var totalWins = 0;
+    var competitiveEligible = 0;
+    var competitiveWins = 0;
+    var coopEligible = 0;
+    var coopWins = 0;
+
+    // opponentId -> accumulated head-to-head data
+    final headToHeadByOpponentId = <String, _HeadToHeadAccumulator>{};
+
+    for (final playthrough in validPlaythroughs) {
+      final boardGame = boardGamesById[playthrough.boardGameId];
+      final gameClassification = boardGame?.settings?.gameClassification ?? GameClassification.Score;
+      final gameFamily = boardGame?.settings?.gameFamily ?? GameFamily.HighestScore;
+      final playScores = scoresByPlaythroughId[playthrough.id] ?? const <Score>[];
+      final subjectScore = playScores.firstWhereOrNullByPlayer(playerId);
+      final isSolo = playthrough.playerIds.length == 1;
+
+      final isWin = _isWin(
+        gameClassification: gameClassification,
+        gameFamily: gameFamily,
+        playScores: playScores,
+        subjectScore: subjectScore,
+      );
+      if (isWin) {
+        totalWins++;
+      }
+
+      if (gameClassification == GameClassification.NoScore) {
+        final cooperativeResult = subjectScore?.noScoreGameResult?.cooperativeGameResult ??
+            playScores
+                .firstWhereOrNullResult()
+                ?.noScoreGameResult
+                ?.cooperativeGameResult;
+        if (cooperativeResult != null) {
+          coopEligible++;
+          if (cooperativeResult == CooperativeGameResult.win) {
+            coopWins++;
+          }
+        }
+      } else {
+        if (!isSolo && (subjectScore?.hasNumericalScore ?? false)) {
+          competitiveEligible++;
+          // [isWin] already reflects membership in winners(gameFamily) for this play.
+          if (isWin) {
+            competitiveWins++;
+          }
+        }
+
+        if (!isSolo) {
+          _accumulateHeadToHead(
+            headToHeadByOpponentId,
+            playerId: playerId,
+            playthrough: playthrough,
+            playScores: playScores,
+            subjectScore: subjectScore,
+            gameFamily: gameFamily,
+          );
+        }
+      }
+    }
+
+    final competitiveWinRate = competitiveEligible == 0 ? null : competitiveWins / competitiveEligible;
+    final coopWinRate = coopEligible == 0 ? null : coopWins / coopEligible;
+
+    final rival = _resolveRival(headToHeadByOpponentId);
+    final nemesis = _resolveNemesis(headToHeadByOpponentId);
+
+    return PlayerOverallStatistics(
+      player: player,
+      totalPlays: validPlaythroughs.length,
+      totalWins: totalWins,
+      competitiveWinRate: competitiveWinRate,
+      coopWinRate: coopWinRate,
+      gamesByPlays: gamesByPlays,
+      rival: rival,
+      nemesis: nemesis,
+      buddies: buddies,
+    );
+  }
+
+  Player _resolvePlayerById(String playerId) {
+    for (final player in _playersStore.players) {
+      if (player.id == playerId) {
+        return player;
+      }
+    }
+
+    return Player(id: playerId);
+  }
+
+  List<GamePlaysCount> _retrieveGamesByPlays(
+    List<Playthrough> validPlaythroughs,
+    Map<String, BoardGameDetails> boardGamesById,
+  ) {
+    final playCountByBoardGameId = <String, int>{};
+    for (final playthrough in validPlaythroughs) {
+      playCountByBoardGameId[playthrough.boardGameId] =
+          (playCountByBoardGameId[playthrough.boardGameId] ?? 0) + 1;
+    }
+
+    final gamesByPlays = playCountByBoardGameId.entries.map((entry) {
+      final BoardGameDetails? boardGame = boardGamesById[entry.key];
+      return GamePlaysCount(
+        boardGameId: entry.key,
+        boardGameName: boardGame?.name ?? entry.key,
+        boardGameImageUrl: boardGame?.imageUrl,
+        playCount: entry.value,
+      );
+    }).toList();
+
+    gamesByPlays.sort((a, b) {
+      final byCount = b.playCount.compareTo(a.playCount);
+      if (byCount != 0) {
+        return byCount;
+      }
+
+      return a.boardGameName.compareTo(b.boardGameName);
+    });
+
+    return gamesByPlays;
+  }
+
+  List<BuddyRecord> _retrieveBuddies(String playerId, List<Playthrough> validPlaythroughs) {
+    final sharedPlaysByBuddyId = <String, int>{};
+    for (final playthrough in validPlaythroughs) {
+      for (final otherPlayerId in playthrough.playerIds) {
+        if (otherPlayerId == playerId) {
+          continue;
+        }
+
+        sharedPlaysByBuddyId[otherPlayerId] = (sharedPlaysByBuddyId[otherPlayerId] ?? 0) + 1;
+      }
+    }
+
+    final buddies = sharedPlaysByBuddyId.entries.map((entry) {
+      final buddy = _resolvePlayerById(entry.key);
+      return BuddyRecord(buddy: buddy, sharedPlaysCount: entry.value);
+    }).toList();
+
+    buddies.sort((a, b) {
+      final byCount = b.sharedPlaysCount.compareTo(a.sharedPlaysCount);
+      if (byCount != 0) {
+        return byCount;
+      }
+
+      return (a.buddy.name ?? a.buddy.id).compareTo(b.buddy.name ?? b.buddy.id);
+    });
+
+    return buddies.take(_maxBuddies).toList();
+  }
+
+  bool _isWin({
+    required GameClassification gameClassification,
+    required GameFamily gameFamily,
+    required List<Score> playScores,
+    required Score? subjectScore,
+  }) {
+    if (gameClassification == GameClassification.NoScore) {
+      final cooperativeResult = subjectScore?.noScoreGameResult?.cooperativeGameResult ??
+          playScores.firstWhereOrNullResult()?.noScoreGameResult?.cooperativeGameResult;
+      return cooperativeResult == CooperativeGameResult.win;
+    }
+
+    if (subjectScore == null) {
+      return false;
+    }
+
+    return playScores.winners(gameFamily).contains(subjectScore);
+  }
+
+  void _accumulateHeadToHead(
+    Map<String, _HeadToHeadAccumulator> headToHeadByOpponentId, {
+    required String playerId,
+    required Playthrough playthrough,
+    required List<Score> playScores,
+    required Score? subjectScore,
+    required GameFamily gameFamily,
+  }) {
+    for (final opponentId in playthrough.playerIds) {
+      if (opponentId == playerId) {
+        continue;
+      }
+
+      final accumulator = headToHeadByOpponentId.putIfAbsent(
+        opponentId,
+        () => _HeadToHeadAccumulator(),
+      );
+      accumulator.sharedCompetitivePlays++;
+
+      if (subjectScore == null) {
+        continue;
+      }
+
+      final opponentScore = playScores.firstWhereOrNullByPlayer(opponentId);
+      if (opponentScore == null) {
+        continue;
+      }
+
+      final comparison = _compareFinish(subjectScore, opponentScore, gameFamily);
+      if (comparison == null || comparison == 0) {
+        continue;
+      }
+
+      if (comparison > 0) {
+        accumulator.wins++;
+      } else {
+        accumulator.losses++;
+      }
+    }
+  }
+
+  /// Compares two scores from the same play, returning:
+  /// - a positive value when [subjectScore] finishes ABOVE [opponentScore]
+  /// - a negative value when [subjectScore] finishes BELOW [opponentScore]
+  /// - `0` when they tie
+  /// - `null` when the two scores cannot be compared
+  int? _compareFinish(Score subjectScore, Score opponentScore, GameFamily gameFamily) {
+    final subjectPlace = subjectScore.scoreGameResult?.place;
+    final opponentPlace = opponentScore.scoreGameResult?.place;
+    if (subjectPlace != null && opponentPlace != null) {
+      if (subjectPlace == opponentPlace) {
+        return 0;
+      }
+
+      return subjectPlace < opponentPlace ? 1 : -1;
+    }
+
+    final subjectValue = subjectScore.score;
+    final opponentValue = opponentScore.score;
+    if (subjectValue == null || opponentValue == null) {
+      return null;
+    }
+
+    if (subjectValue == opponentValue) {
+      return 0;
+    }
+
+    switch (gameFamily) {
+      case GameFamily.HighestScore:
+        return subjectValue > opponentValue ? 1 : -1;
+      case GameFamily.LowestScore:
+        return subjectValue < opponentValue ? 1 : -1;
+      case GameFamily.Cooperative:
+        return null;
+    }
+  }
+
+  HeadToHeadRecord? _resolveRival(Map<String, _HeadToHeadAccumulator> headToHeadByOpponentId) {
+    final eligible = headToHeadByOpponentId.entries
+        .where((entry) =>
+            entry.value.sharedCompetitivePlays >= _minimumSharedCompetitivePlaysForHeadToHead &&
+            entry.value.wins >= 1)
+        .toList();
+    if (eligible.isEmpty) {
+      return null;
+    }
+
+    eligible.sort((a, b) {
+      final byWins = b.value.wins.compareTo(a.value.wins);
+      if (byWins != 0) {
+        return byWins;
+      }
+
+      final byDiff =
+          (b.value.wins - b.value.losses).compareTo(a.value.wins - a.value.losses);
+      if (byDiff != 0) {
+        return byDiff;
+      }
+
+      return _resolvePlayerById(a.key).name?.compareTo(_resolvePlayerById(b.key).name ?? '') ?? 0;
+    });
+
+    final best = eligible.first;
+    return HeadToHeadRecord(
+      opponent: _resolvePlayerById(best.key),
+      wins: best.value.wins,
+      losses: best.value.losses,
+    );
+  }
+
+  HeadToHeadRecord? _resolveNemesis(Map<String, _HeadToHeadAccumulator> headToHeadByOpponentId) {
+    final eligible = headToHeadByOpponentId.entries
+        .where((entry) =>
+            entry.value.sharedCompetitivePlays >= _minimumSharedCompetitivePlaysForHeadToHead &&
+            entry.value.losses >= 1)
+        .toList();
+    if (eligible.isEmpty) {
+      return null;
+    }
+
+    eligible.sort((a, b) {
+      final byLosses = b.value.losses.compareTo(a.value.losses);
+      if (byLosses != 0) {
+        return byLosses;
+      }
+
+      final byDiff =
+          (b.value.losses - b.value.wins).compareTo(a.value.losses - a.value.wins);
+      if (byDiff != 0) {
+        return byDiff;
+      }
+
+      return _resolvePlayerById(a.key).name?.compareTo(_resolvePlayerById(b.key).name ?? '') ?? 0;
+    });
+
+    final worst = eligible.first;
+    return HeadToHeadRecord(
+      opponent: _resolvePlayerById(worst.key),
+      wins: worst.value.wins,
+      losses: worst.value.losses,
+    );
+  }
+}
+
+class _HeadToHeadAccumulator {
+  int wins = 0;
+  int losses = 0;
+  int sharedCompetitivePlays = 0;
+}
+
+extension _ScoresListExtensions on List<Score> {
+  Score? firstWhereOrNullByPlayer(String playerId) {
+    for (final score in this) {
+      if (score.playerId == playerId) {
+        return score;
+      }
+    }
+
+    return null;
+  }
+
+  Score? firstWhereOrNullResult() {
+    for (final score in this) {
+      if (score.noScoreGameResult?.cooperativeGameResult != null) {
+        return score;
+      }
+    }
+
+    return null;
+  }
+}

--- a/board_games_companion/test/extensions/scores_extensions_test.dart
+++ b/board_games_companion/test/extensions/scores_extensions_test.dart
@@ -213,6 +213,67 @@ void main() {
     expect(winners, [lowestScore]);
   });
 
+  test(
+      'GIVEN a collection of scores '
+      'WHEN scores are imported plays with points but no place '
+      'AND the top score is tied between two players '
+      'THEN both tied top scorers should be winners ', () {
+    final firstTiedWinner = emptyScore.copyWith(
+      playerId: '1',
+      scoreGameResult: const ScoreGameResult(points: 10),
+    );
+    final secondTiedWinner = emptyScore.copyWith(
+      playerId: '2',
+      scoreGameResult: const ScoreGameResult(points: 10),
+    );
+    final scores = [
+      emptyScore.copyWith(playerId: '3', scoreGameResult: const ScoreGameResult(points: 7)),
+      firstTiedWinner,
+      secondTiedWinner,
+    ];
+
+    final winners = scores.winners(GameFamily.HighestScore);
+
+    expect(winners.length, 2);
+    expect(winners, [firstTiedWinner, secondTiedWinner]);
+  });
+
+  test(
+      'GIVEN a collection of scores '
+      'WHEN scores are imported plays with points but no place '
+      'AND there is a single distinct top score '
+      'THEN only that single score should be a winner ', () {
+    final highestScore = emptyScore.copyWith(
+      playerId: '1',
+      scoreGameResult: const ScoreGameResult(points: 20),
+    );
+    final scores = [
+      emptyScore.copyWith(playerId: '2', scoreGameResult: const ScoreGameResult(points: 10)),
+      highestScore,
+      emptyScore.copyWith(playerId: '3', scoreGameResult: const ScoreGameResult(points: 3)),
+    ];
+
+    final highestWinners = scores.winners(GameFamily.HighestScore);
+
+    expect(highestWinners.length, 1);
+    expect(highestWinners, [highestScore]);
+
+    final lowestScore = emptyScore.copyWith(
+      playerId: '1',
+      scoreGameResult: const ScoreGameResult(points: 3),
+    );
+    final lowestScores = [
+      emptyScore.copyWith(playerId: '2', scoreGameResult: const ScoreGameResult(points: 20)),
+      lowestScore,
+      emptyScore.copyWith(playerId: '3', scoreGameResult: const ScoreGameResult(points: 10)),
+    ];
+
+    final lowestWinners = lowestScores.winners(GameFamily.LowestScore);
+
+    expect(lowestWinners.length, 1);
+    expect(lowestWinners, [lowestScore]);
+  });
+
   group('GIVEN a collection of different type of scores ', () {
     void validateOrderingEmptyScored(GameFamily gameFamily) {
       test(

--- a/board_games_companion/test/mocks/player_statistics_service_mock.dart
+++ b/board_games_companion/test/mocks/player_statistics_service_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/services/player_statistics_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockPlayerStatisticsService extends Mock implements PlayerStatisticsService {}

--- a/board_games_companion/test/mocks/players_store_mock.dart
+++ b/board_games_companion/test/mocks/players_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/players_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockPlayersStore extends Mock implements PlayersStore {}

--- a/board_games_companion/test/mocks/playthroughs_store_mock.dart
+++ b/board_games_companion/test/mocks/playthroughs_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/playthroughs_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockPlaythroughsStore extends Mock implements PlaythroughsStore {}

--- a/board_games_companion/test/mocks/scores_store_mock.dart
+++ b/board_games_companion/test/mocks/scores_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/scores_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockScoresStore extends Mock implements ScoresStore {}

--- a/board_games_companion/test/services/player_statistics_service_test.dart
+++ b/board_games_companion/test/services/player_statistics_service_test.dart
@@ -1,0 +1,538 @@
+import 'package:board_games_companion/common/enums/game_classification.dart';
+import 'package:board_games_companion/common/enums/game_family.dart';
+import 'package:board_games_companion/common/enums/playthrough_status.dart';
+import 'package:board_games_companion/models/hive/board_game_details.dart';
+import 'package:board_games_companion/models/hive/board_game_settings.dart';
+import 'package:board_games_companion/models/hive/no_score_game_result.dart';
+import 'package:board_games_companion/models/hive/player.dart';
+import 'package:board_games_companion/models/hive/playthrough.dart';
+import 'package:board_games_companion/models/hive/score.dart';
+import 'package:board_games_companion/models/hive/score_game_results.dart';
+import 'package:board_games_companion/services/player_statistics_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx/mobx.dart' hide when;
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/board_games_store_mock.dart';
+import '../mocks/players_store_mock.dart';
+import '../mocks/playthroughs_store_mock.dart';
+import '../mocks/scores_store_mock.dart';
+
+void main() {
+  late MockPlayersStore mockPlayersStore;
+  late MockPlaythroughsStore mockPlaythroughsStore;
+  late MockScoresStore mockScoresStore;
+  late MockBoardGamesStore mockBoardGamesStore;
+
+  late PlayerStatisticsService playerStatisticsService;
+
+  const subjectPlayerId = 'subject';
+  const subjectPlayer = Player(id: subjectPlayerId, name: 'Subject');
+
+  const competitiveBoardGameId = 'competitive-board-game';
+  const coopBoardGameId = 'coop-board-game';
+
+  const competitiveBoardGame = BoardGameDetails(
+    id: competitiveBoardGameId,
+    name: 'Ticket to Ride',
+    settings: BoardGameSettings(
+      gameFamily: GameFamily.HighestScore,
+      gameClassification: GameClassification.Score,
+    ),
+  );
+
+  const coopBoardGame = BoardGameDetails(
+    id: coopBoardGameId,
+    name: 'Pandemic',
+    settings: BoardGameSettings(
+      gameFamily: GameFamily.Cooperative,
+      gameClassification: GameClassification.NoScore,
+    ),
+  );
+
+  void setUpStores({
+    required List<Player> players,
+    required List<Playthrough> playthroughs,
+    required List<Score> scores,
+    required Map<String, BoardGameDetails> boardGames,
+  }) {
+    when(() => mockPlayersStore.players).thenReturn(ObservableList.of(players));
+    when(() => mockPlaythroughsStore.playthroughs).thenReturn(ObservableList.of(playthroughs));
+    when(() => mockScoresStore.scores).thenReturn(ObservableList.of(scores));
+    when(() => mockBoardGamesStore.allBoardGamesMap).thenReturn(ObservableMap.of(boardGames));
+  }
+
+  Playthrough playthrough(
+    String id, {
+    required String boardGameId,
+    required List<String> playerIds,
+    PlaythroughStatus status = PlaythroughStatus.Finished,
+    bool? isDeleted = false,
+  }) =>
+      Playthrough(
+        id: id,
+        boardGameId: boardGameId,
+        playerIds: playerIds,
+        scoreIds: const [],
+        startDate: DateTime(2024),
+        status: status,
+        isDeleted: isDeleted,
+      );
+
+  Score competitiveScore(
+    String id, {
+    required String playthroughId,
+    required String playerId,
+    int? place,
+    double? points,
+  }) =>
+      Score(
+        id: id,
+        playthroughId: playthroughId,
+        playerId: playerId,
+        boardGameId: competitiveBoardGameId,
+        scoreGameResult: (place != null || points != null)
+            ? ScoreGameResult(place: place, points: points)
+            : null,
+      );
+
+  Score coopScore(
+    String id, {
+    required String playthroughId,
+    required String playerId,
+    required CooperativeGameResult result,
+  }) =>
+      Score(
+        id: id,
+        playthroughId: playthroughId,
+        playerId: playerId,
+        boardGameId: coopBoardGameId,
+        noScoreGameResult: NoScoreGameResult(cooperativeGameResult: result),
+      );
+
+  setUp(() {
+    mockPlayersStore = MockPlayersStore();
+    mockPlaythroughsStore = MockPlaythroughsStore();
+    mockScoresStore = MockScoresStore();
+    mockBoardGamesStore = MockBoardGamesStore();
+
+    playerStatisticsService = PlayerStatisticsService(
+      mockPlayersStore,
+      mockPlaythroughsStore,
+      mockScoresStore,
+      mockBoardGamesStore,
+    );
+  });
+
+  group('GIVEN a competitive play with tied first place scores ', () {
+    test(
+        'WHEN retrieving player statistics for one of the tied winners '
+        'THEN totalWins counts the tied win ', () {
+      const opponentId = 'opponent-1';
+      final play = playthrough('p1',
+          boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]);
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: opponentId, name: 'Opponent')],
+        playthroughs: [play],
+        scores: [
+          competitiveScore('s1', playthroughId: 'p1', playerId: subjectPlayerId, place: 1, points: 10),
+          competitiveScore('s2', playthroughId: 'p1', playerId: opponentId, place: 1, points: 10),
+        ],
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalWins, 1);
+      expect(result.totalPlays, 1);
+    });
+  });
+
+  group('GIVEN a competitive play with a missing result for the subject ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN the play is excluded from win rate and head-to-head but still counted elsewhere ', () {
+      const opponentId = 'opponent-1';
+      final plays = [
+        for (var i = 0; i < 3; i++)
+          playthrough('shared-$i',
+              boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]),
+        playthrough('missing',
+            boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]),
+      ];
+
+      final scores = <Score>[
+        for (var i = 0; i < 3; i++) ...[
+          competitiveScore('sub-$i',
+              playthroughId: 'shared-$i', playerId: subjectPlayerId, place: 1, points: 100),
+          competitiveScore('opp-$i',
+              playthroughId: 'shared-$i', playerId: opponentId, place: 2, points: 50),
+        ],
+        // subject has no score recorded in this play
+        competitiveScore('opp-missing',
+            playthroughId: 'missing', playerId: opponentId, place: 1, points: 100),
+      ];
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: opponentId, name: 'Opponent')],
+        playthroughs: plays,
+        scores: scores,
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalPlays, 4);
+      expect(result.competitiveWinRate, 1.0); // 3 eligible plays, all wins
+      expect(result.buddies, hasLength(1));
+      expect(result.buddies.first.sharedPlaysCount, 4);
+      expect(result.gamesByPlays.single.playCount, 4);
+    });
+  });
+
+  group('GIVEN a co-op win and a co-op loss ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN coopWinRate is correct, competitiveWinRate is null, and totalWins counts the win ', () {
+      const otherId = 'other';
+      final plays = [
+        playthrough('coop-win', boardGameId: coopBoardGameId, playerIds: const [subjectPlayerId, otherId]),
+        playthrough('coop-loss', boardGameId: coopBoardGameId, playerIds: const [subjectPlayerId, otherId]),
+      ];
+      final scores = [
+        coopScore('s1', playthroughId: 'coop-win', playerId: subjectPlayerId, result: CooperativeGameResult.win),
+        coopScore('s2', playthroughId: 'coop-win', playerId: otherId, result: CooperativeGameResult.win),
+        coopScore('s3', playthroughId: 'coop-loss', playerId: subjectPlayerId, result: CooperativeGameResult.loss),
+        coopScore('s4', playthroughId: 'coop-loss', playerId: otherId, result: CooperativeGameResult.loss),
+      ];
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: otherId, name: 'Other')],
+        playthroughs: plays,
+        scores: scores,
+        boardGames: const {coopBoardGameId: coopBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.coopWinRate, 0.5);
+      expect(result.competitiveWinRate, isNull);
+      expect(result.totalWins, 1);
+      expect(result.totalPlays, 2);
+    });
+  });
+
+  group('GIVEN a solo play ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN it is counted in totalPlays but excluded from competitiveWinRate denominator ', () {
+      final play =
+          playthrough('solo', boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId]);
+
+      setUpStores(
+        players: const [subjectPlayer],
+        playthroughs: [play],
+        scores: [
+          competitiveScore('s1', playthroughId: 'solo', playerId: subjectPlayerId, place: 1, points: 42),
+        ],
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalPlays, 1);
+      expect(result.totalWins, 1);
+      expect(result.competitiveWinRate, isNull);
+    });
+  });
+
+  group('GIVEN a player whose plays are all co-op ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN competitiveWinRate is null and coopWinRate is set ', () {
+      const otherId = 'other';
+      final play =
+          playthrough('coop', boardGameId: coopBoardGameId, playerIds: const [subjectPlayerId, otherId]);
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: otherId)],
+        playthroughs: [play],
+        scores: [
+          coopScore('s1', playthroughId: 'coop', playerId: subjectPlayerId, result: CooperativeGameResult.win),
+        ],
+        boardGames: const {coopBoardGameId: coopBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.competitiveWinRate, isNull);
+      expect(result.coopWinRate, 1.0);
+    });
+  });
+
+  group('GIVEN an opponent below the three-play head-to-head floor ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN that opponent is not returned as rival or nemesis ', () {
+      const opponentId = 'opponent';
+      final plays = [
+        for (var i = 0; i < 2; i++)
+          playthrough('p-$i',
+              boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]),
+      ];
+      final scores = <Score>[
+        for (var i = 0; i < 2; i++) ...[
+          competitiveScore('sub-$i', playthroughId: 'p-$i', playerId: subjectPlayerId, place: 1),
+          competitiveScore('opp-$i', playthroughId: 'p-$i', playerId: opponentId, place: 2),
+        ],
+      ];
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: opponentId, name: 'Opponent')],
+        playthroughs: plays,
+        scores: scores,
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.rival, isNull);
+      expect(result.nemesis, isNull);
+    });
+  });
+
+  group('GIVEN a deleted player appears as a rival ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN the deleted opponent is still returned as rival ', () {
+      const opponentId = 'deleted-opponent';
+      final plays = [
+        for (var i = 0; i < 3; i++)
+          playthrough('p-$i',
+              boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]),
+      ];
+      final scores = <Score>[
+        for (var i = 0; i < 3; i++) ...[
+          competitiveScore('sub-$i', playthroughId: 'p-$i', playerId: subjectPlayerId, place: 1),
+          competitiveScore('opp-$i', playthroughId: 'p-$i', playerId: opponentId, place: 2),
+        ],
+      ];
+
+      setUpStores(
+        players: const [
+          subjectPlayer,
+          Player(id: opponentId, name: 'Deleted Opponent', isDeleted: true),
+        ],
+        playthroughs: plays,
+        scores: scores,
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.rival, isNotNull);
+      expect(result.rival!.opponent.id, opponentId);
+      expect(result.rival!.opponent.isDeleted, isTrue);
+      expect(result.rival!.wins, 3);
+      expect(result.rival!.losses, 0);
+    });
+  });
+
+  group('GIVEN a deleted playthrough ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN it is excluded from every statistic ', () {
+      final deletedPlay = playthrough('deleted',
+          boardGameId: competitiveBoardGameId,
+          playerIds: const [subjectPlayerId, 'opponent'],
+          isDeleted: true);
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: 'opponent')],
+        playthroughs: [deletedPlay],
+        scores: [
+          competitiveScore('s1', playthroughId: 'deleted', playerId: subjectPlayerId, place: 1),
+          competitiveScore('s2', playthroughId: 'deleted', playerId: 'opponent', place: 2),
+        ],
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalPlays, 0);
+      expect(result.hasNoPlays, isTrue);
+      expect(result.totalWins, 0);
+      expect(result.gamesByPlays, isEmpty);
+      expect(result.buddies, isEmpty);
+    });
+  });
+
+  group('GIVEN a play imported without a place, two tied top scorers ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN both tied top scorers count as winners ', () {
+      const opponentId = 'opponent';
+      final play = playthrough('imported',
+          boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, opponentId]);
+
+      setUpStores(
+        players: const [subjectPlayer, Player(id: opponentId)],
+        playthroughs: [play],
+        scores: [
+          competitiveScore('s1', playthroughId: 'imported', playerId: subjectPlayerId, points: 50),
+          competitiveScore('s2', playthroughId: 'imported', playerId: opponentId, points: 50),
+        ],
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalWins, 1);
+      expect(result.competitiveWinRate, 1.0);
+    });
+  });
+
+  group('GIVEN a player with no plays at all ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN totals are zero/empty/null ', () {
+      setUpStores(
+        players: const [subjectPlayer],
+        playthroughs: const [],
+        scores: const [],
+        boardGames: const {},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalPlays, 0);
+      expect(result.hasNoPlays, isTrue);
+      expect(result.totalWins, 0);
+      expect(result.gamesByPlays, isEmpty);
+      expect(result.buddies, isEmpty);
+      expect(result.competitiveWinRate, isNull);
+      expect(result.coopWinRate, isNull);
+      expect(result.rival, isNull);
+      expect(result.nemesis, isNull);
+    });
+  });
+
+  group('GIVEN plays across multiple games and opponents ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN gamesByPlays is ordered by playCount desc and buddies ordered/top-5 with shared counts ', () {
+      const otherBoardGameId = 'other-board-game';
+      const otherBoardGame = BoardGameDetails(
+        id: otherBoardGameId,
+        name: 'Catan',
+        settings: BoardGameSettings(
+          gameFamily: GameFamily.HighestScore,
+          gameClassification: GameClassification.Score,
+        ),
+      );
+
+      final buddyIds = List.generate(6, (i) => 'buddy-$i');
+      final players = [subjectPlayer, ...buddyIds.map((id) => Player(id: id, name: id))];
+
+      final playthroughs = <Playthrough>[];
+      final scores = <Score>[];
+
+      // 3 plays of competitiveBoardGame with buddy-0 (most shared plays: 3)
+      for (var i = 0; i < 3; i++) {
+        final id = 'ttr-$i';
+        playthroughs.add(playthrough(id,
+            boardGameId: competitiveBoardGameId, playerIds: [subjectPlayerId, buddyIds[0]]));
+        scores.add(competitiveScore('ttr-sub-$i', playthroughId: id, playerId: subjectPlayerId, place: 1));
+        scores.add(competitiveScore('ttr-opp-$i', playthroughId: id, playerId: buddyIds[0], place: 2));
+      }
+
+      // 1 play of otherBoardGame with buddies 1-5 (5 buddies, each sharedPlaysCount 1)
+      playthroughs.add(playthrough('catan-1',
+          boardGameId: otherBoardGameId,
+          playerIds: [subjectPlayerId, ...buddyIds.sublist(1)]));
+      for (var i = 1; i < 6; i++) {
+        scores.add(competitiveScore('catan-$i', playthroughId: 'catan-1', playerId: buddyIds[i], place: i));
+      }
+      scores.add(competitiveScore('catan-sub', playthroughId: 'catan-1', playerId: subjectPlayerId, place: 6));
+
+      setUpStores(
+        players: players,
+        playthroughs: playthroughs,
+        scores: scores,
+        boardGames: const {
+          competitiveBoardGameId: competitiveBoardGame,
+          otherBoardGameId: otherBoardGame,
+        },
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.totalPlays, 4);
+      expect(result.gamesByPlays.first.boardGameId, competitiveBoardGameId);
+      expect(result.gamesByPlays.first.playCount, 3);
+      expect(result.gamesByPlays.last.boardGameId, otherBoardGameId);
+      expect(result.gamesByPlays.last.playCount, 1);
+
+      expect(result.buddies, hasLength(5)); // top 5 of 6 total buddies
+      expect(result.buddies.first.buddy.id, buddyIds[0]);
+      expect(result.buddies.first.sharedPlaysCount, 3);
+    });
+  });
+
+  group('GIVEN a subject with >=3 shared competitive plays against an opponent, asymmetric record ', () {
+    test(
+        'WHEN retrieving player statistics '
+        'THEN wins/losses record is correct and the opponent is both a candidate rival and nemesis pool member ', () {
+      const rivalId = 'rival'; // subject beats rival often
+      const nemesisId = 'nemesis'; // subject loses to nemesis often
+
+      final playthroughs = <Playthrough>[];
+      final scores = <Score>[];
+
+      // Subject beats rival 3 times, loses once (net +2)
+      for (var i = 0; i < 4; i++) {
+        final id = 'vs-rival-$i';
+        playthroughs.add(
+            playthrough(id, boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, rivalId]));
+        final subjectWinsThisRound = i != 3;
+        scores.add(competitiveScore('r-sub-$i',
+            playthroughId: id, playerId: subjectPlayerId, place: subjectWinsThisRound ? 1 : 2));
+        scores.add(competitiveScore('r-opp-$i',
+            playthroughId: id, playerId: rivalId, place: subjectWinsThisRound ? 2 : 1));
+      }
+
+      // Subject loses to nemesis 4 times, wins never
+      for (var i = 0; i < 4; i++) {
+        final id = 'vs-nemesis-$i';
+        playthroughs.add(playthrough(id,
+            boardGameId: competitiveBoardGameId, playerIds: const [subjectPlayerId, nemesisId]));
+        scores.add(competitiveScore('n-sub-$i', playthroughId: id, playerId: subjectPlayerId, place: 2));
+        scores.add(competitiveScore('n-opp-$i', playthroughId: id, playerId: nemesisId, place: 1));
+      }
+
+      setUpStores(
+        players: const [
+          subjectPlayer,
+          Player(id: rivalId, name: 'Rival'),
+          Player(id: nemesisId, name: 'Nemesis'),
+        ],
+        playthroughs: playthroughs,
+        scores: scores,
+        boardGames: const {competitiveBoardGameId: competitiveBoardGame},
+      );
+
+      final result = playerStatisticsService.retrievePlayerStatistics(subjectPlayerId);
+
+      expect(result.rival, isNotNull);
+      expect(result.rival!.opponent.id, rivalId);
+      expect(result.rival!.wins, 3);
+      expect(result.rival!.losses, 1);
+
+      expect(result.nemesis, isNotNull);
+      expect(result.nemesis!.opponent.id, nemesisId);
+      expect(result.nemesis!.wins, 0);
+      expect(result.nemesis!.losses, 4);
+    });
+  });
+}

--- a/board_games_companion/test/view_models/player_statistics_view_model_test.dart
+++ b/board_games_companion/test/view_models/player_statistics_view_model_test.dart
@@ -1,0 +1,211 @@
+import 'package:board_games_companion/models/hive/player.dart';
+import 'package:board_games_companion/models/player_overall_statistics.dart';
+import 'package:board_games_companion/pages/player_statistics/player_statistics_view_model.dart';
+import 'package:board_games_companion/pages/player_statistics/player_statistics_visual_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx/mobx.dart' hide when;
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/board_games_store_mock.dart';
+import '../mocks/player_statistics_service_mock.dart';
+import '../mocks/players_store_mock.dart';
+import '../mocks/playthroughs_store_mock.dart';
+import '../mocks/scores_store_mock.dart';
+
+void main() {
+  late MockPlayerStatisticsService mockPlayerStatisticsService;
+  late MockPlayersStore mockPlayersStore;
+  late MockPlaythroughsStore mockPlaythroughsStore;
+  late MockScoresStore mockScoresStore;
+  late MockBoardGamesStore mockBoardGamesStore;
+
+  late PlayerStatisticsViewModel playerStatisticsViewModel;
+
+  const testPlayer = Player(id: 'player1', name: 'Alice');
+
+  setUp(() {
+    mockPlayerStatisticsService = MockPlayerStatisticsService();
+    mockPlayersStore = MockPlayersStore();
+    mockPlaythroughsStore = MockPlaythroughsStore();
+    mockScoresStore = MockScoresStore();
+    mockBoardGamesStore = MockBoardGamesStore();
+
+    when(() => mockPlayersStore.loadPlayers()).thenAnswer((_) => Future.value());
+    when(() => mockPlaythroughsStore.loadPlaythroughs()).thenAnswer((_) => Future.value());
+    when(() => mockScoresStore.loadScores()).thenAnswer((_) => Future.value());
+    when(() => mockBoardGamesStore.loadBoardGames()).thenAnswer((_) => Future.value());
+    when(() => mockPlayersStore.players).thenReturn(ObservableList.of([testPlayer]));
+
+    playerStatisticsViewModel = PlayerStatisticsViewModel(
+      mockPlayerStatisticsService,
+      mockPlayersStore,
+      mockPlaythroughsStore,
+      mockScoresStore,
+      mockBoardGamesStore,
+    );
+  });
+
+  group('GIVEN a player with no recorded plays ', () {
+    test(
+        'WHEN player statistics are loaded '
+        'THEN visual state is PlayerStatisticsEmpty ', () async {
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any())).thenReturn(
+        const PlayerOverallStatistics(
+          player: testPlayer,
+          totalPlays: 0,
+          totalWins: 0,
+        ),
+      );
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.visualState, isA<PlayerStatisticsEmpty>());
+    });
+  });
+
+  group('GIVEN a player with a rich set of recorded plays ', () {
+    test(
+        'WHEN player statistics are loaded '
+        'THEN visual state is PlayerStatisticsLoaded carrying the statistics ', () async {
+      const statistics = PlayerOverallStatistics(
+        player: testPlayer,
+        totalPlays: 10,
+        totalWins: 6,
+        competitiveWinRate: 0.6,
+        coopWinRate: 0.5,
+        gamesByPlays: [
+          GamePlaysCount(boardGameId: 'g1', boardGameName: 'Catan', playCount: 5),
+        ],
+        rival: HeadToHeadRecord(
+          opponent: Player(id: 'player2', name: 'Bob'),
+          wins: 3,
+          losses: 1,
+        ),
+        nemesis: HeadToHeadRecord(
+          opponent: Player(id: 'player3', name: 'Carol'),
+          wins: 1,
+          losses: 4,
+        ),
+        buddies: [
+          BuddyRecord(buddy: Player(id: 'player2', name: 'Bob'), sharedPlaysCount: 8),
+        ],
+      );
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any()))
+          .thenReturn(statistics);
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.visualState, isA<PlayerStatisticsLoaded>());
+      expect(
+        (playerStatisticsViewModel.visualState as PlayerStatisticsLoaded).statistics,
+        statistics,
+      );
+    });
+  });
+
+  group('GIVEN a player with plays but no rival, nemesis, coop plays or buddies ', () {
+    test(
+        'WHEN player statistics are loaded '
+        'THEN visual state is PlayerStatisticsLoaded preserving the nulls and empties ', () async {
+      const statistics = PlayerOverallStatistics(
+        player: testPlayer,
+        totalPlays: 4,
+        totalWins: 1,
+        competitiveWinRate: 0.25,
+      );
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any()))
+          .thenReturn(statistics);
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.visualState, isA<PlayerStatisticsLoaded>());
+      final loaded = playerStatisticsViewModel.visualState as PlayerStatisticsLoaded;
+      expect(loaded.statistics.rival, isNull);
+      expect(loaded.statistics.nemesis, isNull);
+      expect(loaded.statistics.coopWinRate, isNull);
+      expect(loaded.statistics.buddies, isEmpty);
+    });
+  });
+
+  group('GIVEN a player with more games played than the collapsed count ', () {
+    test(
+        'WHEN player statistics are loaded '
+        'THEN games list can be expanded and displays all games ', () async {
+      final gamesByPlays = List.generate(
+        7,
+        (index) => GamePlaysCount(boardGameId: 'g$index', boardGameName: 'Game $index', playCount: index),
+      );
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any())).thenReturn(
+        PlayerOverallStatistics(
+          player: testPlayer,
+          totalPlays: 20,
+          totalWins: 10,
+          gamesByPlays: gamesByPlays,
+        ),
+      );
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.canExpandGames, isTrue);
+      expect(playerStatisticsViewModel.displayedGames.length, 5);
+
+      playerStatisticsViewModel.toggleGamesExpansion();
+
+      expect(playerStatisticsViewModel.displayedGames.length, 7);
+    });
+
+    test(
+        'WHEN there are fewer games played than the collapsed count '
+        'THEN games list cannot be expanded and displays all games ', () async {
+      final gamesByPlays = List.generate(
+        3,
+        (index) => GamePlaysCount(boardGameId: 'g$index', boardGameName: 'Game $index', playCount: index),
+      );
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any())).thenReturn(
+        PlayerOverallStatistics(
+          player: testPlayer,
+          totalPlays: 5,
+          totalWins: 2,
+          gamesByPlays: gamesByPlays,
+        ),
+      );
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.canExpandGames, isFalse);
+      expect(playerStatisticsViewModel.displayedGames.length, 3);
+    });
+  });
+
+  group('GIVEN a deleted player ', () {
+    test(
+        'WHEN player statistics are loaded '
+        'THEN isPlayerDeleted is true ', () async {
+      const deletedPlayer = Player(id: 'player1', name: 'Alice', isDeleted: true);
+      when(() => mockPlayersStore.players).thenReturn(ObservableList.of([deletedPlayer]));
+      when(() => mockPlayerStatisticsService.retrievePlayerStatistics(any())).thenReturn(
+        const PlayerOverallStatistics(
+          player: deletedPlayer,
+          totalPlays: 3,
+          totalWins: 1,
+        ),
+      );
+
+      playerStatisticsViewModel.setPlayer(testPlayer);
+      playerStatisticsViewModel.loadPlayerStatistics();
+      await playerStatisticsViewModel.futureLoadStatistics;
+
+      expect(playerStatisticsViewModel.isPlayerDeleted, isTrue);
+    });
+  });
+}

--- a/docs/adr/0004-personal-player-statistics.md
+++ b/docs/adr/0004-personal-player-statistics.md
@@ -1,0 +1,42 @@
+# Personal player statistics: rival/nemesis model and split win rates
+
+Tapping a player now opens a read-only statistics page describing that person across every game they have played. Almost all of it — total plays, games by plays, buddies — is arithmetic with one obvious answer. Two decisions are not, and both are hard to walk back once players start reading numbers and forming expectations about them: **how a rival and a nemesis are defined**, and **how a win rate is reported**. This ADR records those two.
+
+All statistics are computed on demand from the players, playthroughs and scores already in memory, joined to each game's settings to resolve whether a result is a place or a shared outcome. Finished, non-deleted playthroughs only; deleted players stay in other players' numbers and keep a reachable page.
+
+## Status
+
+accepted
+
+## Consequences
+
+- **Rival and nemesis are pairwise within a competitive play, not derived from wins.** In each competitive play a player beats everyone they finish above and loses to everyone they finish below — placing third of six records two beats and two losses, not nothing. Beating is *finishing above*, decided by place when recorded and by score otherwise; a tie for a place is neither a beat nor a loss. Rival is the opponent beaten most, nemesis the opponent lost to most, each shown with the head-to-head record. Co-op plays contribute nothing here, because people you only cooperate with are not opponents.
+- **The relation is directional and that is correct.** Your rival's rival is usually not you. Reviewers and users will read this as a bug; it is the definition. The page and this ADR both call it out so the asymmetry is not "fixed" into a symmetric relation later.
+- **A three-play floor gates rivalry.** An opponent is only eligible once the two have met in at least three competitive plays, so one unlucky evening cannot crown a nemesis. The cost is that a genuinely new player shows only a header and totals — a truthful sparse page rather than a broken-looking one — and the feature is therefore hard to appreciate on a fresh install. That trade is deliberate.
+- **Win rate is two figures, never one.** Competitive win rate and co-op win rate are reported side by side and never summed or averaged into a single percentage. A co-op outcome belongs to the whole table, so folding it into a competitive record would let a run of hard co-op games make a strong competitive player look weak.
+- **Solo plays count as plays but not as competitive opposition.** A solo play is in total plays and can be an absolute win, but it is excluded from the competitive win rate denominator, because that number is meant to describe beating people.
+- **Ties for first are wins for everyone tied, including imported plays.** This depends on the winners helper returning all tied top results rather than one — a prerequisite bug fix, since plays imported from BoardGameGeek record points but no place and previously contributed no clean winner.
+- **Introducing a time period later is additive.** The page is all-time with no period selector. Adding one means giving the plays-tab period vocabulary an explicit "all time" option, so both surfaces describe periods identically — not reworking these definitions.
+
+## Considered options
+
+### Defining rival and nemesis
+
+- **Pairwise "finishing above" within each competitive play, floored at three shared plays** (chosen: matches how players narrate a table — "I beat three of them" — and rewards a strong mid-pack finish rather than only outright wins)
+- **Only the winner beats everyone; everyone else the winner beats** (rejected: throws away every result between non-winners, so a consistent second-place finisher has no recorded rivalry with the people they routinely edge out)
+- **Rank purely by win count with no floor** (rejected: a single lucky or unlucky play crowns a rival or nemesis, which is exactly the noise the page should not amplify)
+- **Symmetric rivalry — the pair's combined record decides both players' rival** (rejected: it reads as less surprising, but it is a different, weaker claim; "who do *I* beat most" is the question players actually ask, and it is inherently directional)
+- **Include co-op plays as shared opposition** (rejected: cooperating with someone is not competing against them, and counting it would invent rivalries out of games nobody was playing to win)
+
+### Reporting win rate
+
+- **Two separate figures, competitive and co-op, never blended** (chosen: the two outcomes mean different things — one is personal, one is the table's — and a single number would silently mix them)
+- **One overall win rate across all plays** (rejected: a co-op loss and a competitive loss are not the same event, and a combined rate hides which one a player is actually good or bad at)
+- **Competitive win rate including solo plays** (rejected: a solo win has no opponent, so counting it inflates a number meant to describe beating people)
+- **A separate solo win rate** (rejected: not asked for, and it would add a third number to a page whose point is legibility)
+
+### Where the numbers come from
+
+- **Compute on demand from the in-memory stores, uncached** (chosen: the stores already hold everything, the work is a linear pass with a pairwise pass inside each play, and caching would add an invalidation problem for no measurable gain)
+- **Precompute and cache per player, invalidated on any playthrough or score change** (rejected: the invalidation surface is every write path, and the win it buys is unmeasurable at this data size)
+- **Derive statistics from scores alone** (rejected: whether a recorded result is a place or a shared outcome is a property of the game's settings, so scores must be joined to settings — statistics cannot be read off scores by themselves)


### PR DESCRIPTION
Closes #355.

Tapping a player now opens a read-only statistics page describing their record across every game they have played — instead of dropping into the edit form. Editing moves behind an explicit edit action on the page.

## What's on the page
Composed in order: header (avatar, name, deleted banner when applicable) → totals and the two win rates → games by plays (top five, expandable) → rival → nemesis → buddies. Sparse sections are hidden rather than shown empty; a player with no plays gets a single empty state.

## Key decisions
- **A statistics service is the single seam.** `PlayerStatisticsService` computes an immutable `PlayerOverallStatistics` aggregate on demand from the players, playthroughs, scores and board-game stores — no caching. Finished, non-deleted playthroughs only; deleted players stay in other players' numbers and keep a reachable page.
- **Win rate is two figures, never blended** — competitive (excludes solo) and co-op (whole-table outcome) reported separately.
- **Rival/nemesis are pairwise "finishing above" within competitive plays**, floored at three shared competitive plays; co-op plays excluded. The relation is directional by design (your rival's rival is rarely you).
- **Fixed the `winners()` helper** to return all tied top scorers in the no-place fallback, so ties and BGG-imported plays (points, no place) count. Prerequisite bug fix with its own tests.
- **Navigation:** players list and the per-player rows on a game's statistics page now point at the new page; rival/nemesis/buddy rows push onto the stack; games rows open the game's record.
- **Docs:** domain language recorded in `CONTEXT.md` (Statistics) and the rival/nemesis + split-win-rate decisions in `ADR-0004`.

## Tests
Unit tests for the winners fix (2), the statistics service (12 — ties, missing results, co-op, solo, the three-play floor, deleted players/playthroughs, imported plays, ordering, rival/nemesis asymmetry), and the view model's visual states (6). No widget tests for the page — it is a straight projection of the aggregate.

Full suite: `+60 -1`. The one failure (`board_game_details_page_test.dart`) is a **pre-existing, unrelated** `font_awesome_flutter 10.12.0` incompatibility with a newer local Flutter SDK (`IconData` became `final`); it does not occur on the project's pinned Flutter/CI. `flutter analyze` is clean on all new/edited files.

## Notes for reviewers
- Solo competitive plays count toward **absolute** wins but are excluded from the **competitive win rate** (AC #9 scopes the solo exclusion to the rate only).
- Winner detection is pinned to the `winners()` helper per the spec; a competitive result recorded by place with no points would not register there, but that shape does not occur in this app's data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)