### PR TITLE
fix: scores partially saving on the edit playthrough page (#72)

### DIFF
--- a/board_games_companion/lib/pages/edit_playthrough/edit_playthrough_view_model.dart
+++ b/board_games_companion/lib/pages/edit_playthrough/edit_playthrough_view_model.dart
@@ -180,8 +180,10 @@ abstract class _EditPlaythoughViewModel with Store {
       return false;
     });
 
-    if (playerScore == null ||
-        (playerScore.score.hasResult && playerScore.score.score == newScore)) {
+    // Only skip when the resolved numerical result is already the requested score. Guarding on
+    // `hasResult` (rather than the resolved points) used to swallow legitimate updates - e.g. a
+    // score still stored in the deprecated `value` format never got migrated to a ScoreGameResult.
+    if (playerScore == null || playerScore.score.scoreGameResult?.points == newScore) {
       return;
     }
 

--- a/board_games_companion/lib/stores/game_playthroughs_details_store.dart
+++ b/board_games_companion/lib/stores/game_playthroughs_details_store.dart
@@ -145,18 +145,20 @@ abstract class _GamePlaythroughsDetailsStore with Store {
       final updateSuceeded =
           await _playthroughsStore.updatePlaythrough(playthroughDetails!.playthrough);
       if (updateSuceeded) {
-        // MK Update playthrough's player scores
-        for (final playerScoreId in originalPlaythrough.scoreIds) {
-          final playerScore = playthroughDetails.playerScores
-              .firstWhereOrNull((playerScore) => playerScore.score.id == playerScoreId);
-          // MK Delete if not present anymore
-          if (playerScore == null) {
-            await _scoresStore.deleteScore(playerScoreId);
-            continue;
-          }
-
-          // MK Add/Update extings ones
+        // MK Persist every current player score. Iterating the *current* scores (rather than the
+        //    original scoreIds) ensures newly added scores - and scores that don't yet carry a
+        //    persisted id - are saved instead of being silently dropped.
+        for (final playerScore in playthroughDetails.playerScores) {
           await _scoresStore.addOrUpdateScore(playerScore.score);
+        }
+
+        // MK Delete scores that belonged to the playthrough originally but are no longer present.
+        final currentScoreIds =
+            playthroughDetails.playerScores.map((playerScore) => playerScore.score.id).toSet();
+        for (final originalScoreId in originalPlaythrough.scoreIds) {
+          if (!currentScoreIds.contains(originalScoreId)) {
+            await _scoresStore.deleteScore(originalScoreId);
+          }
         }
 
         loadPlaythroughsDetails();

--- a/board_games_companion/test/mocks/players_store_mock.dart
+++ b/board_games_companion/test/mocks/players_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/players_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockPlayersStore extends Mock implements PlayersStore {}

--- a/board_games_companion/test/mocks/playthroughs_store_mock.dart
+++ b/board_games_companion/test/mocks/playthroughs_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/playthroughs_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockPlaythroughsStore extends Mock implements PlaythroughsStore {}

--- a/board_games_companion/test/mocks/scores_store_mock.dart
+++ b/board_games_companion/test/mocks/scores_store_mock.dart
@@ -1,0 +1,4 @@
+import 'package:board_games_companion/stores/scores_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockScoresStore extends Mock implements ScoresStore {}

--- a/board_games_companion/test/stores/game_playthroughs_details_store_test.dart
+++ b/board_games_companion/test/stores/game_playthroughs_details_store_test.dart
@@ -1,0 +1,159 @@
+import 'package:board_games_companion/models/hive/board_game_details.dart';
+import 'package:board_games_companion/models/hive/player.dart';
+import 'package:board_games_companion/models/hive/playthrough.dart';
+import 'package:board_games_companion/models/hive/score.dart';
+import 'package:board_games_companion/models/hive/score_game_results.dart';
+import 'package:board_games_companion/models/player_score.dart';
+import 'package:board_games_companion/models/playthroughs/playthrough_details.dart';
+import 'package:board_games_companion/stores/game_playthroughs_details_store.dart';
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx/mobx.dart' show ObservableList, ObservableMap;
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/board_games_store_mock.dart';
+import '../mocks/players_store_mock.dart';
+import '../mocks/playthroughs_store_mock.dart';
+import '../mocks/scores_store_mock.dart';
+
+class _FakeScore extends Fake implements Score {}
+
+class _FakePlaythrough extends Fake implements Playthrough {}
+
+void main() {
+  final mockPlaythroughsStore = MockPlaythroughsStore();
+  final mockScoresStore = MockScoresStore();
+  final mockPlayersStore = MockPlayersStore();
+  final mockBoardGamesStore = MockBoardGamesStore();
+
+  // The board game the store is scoped to. It is deliberately DIFFERENT from the
+  // playthrough's board game id below so that the `playthroughs` computed (used by
+  // loadPlaythroughsDetails at the end of updatePlaythrough) filters down to empty
+  // and stays a safe no-op, while the raw list still contains the original.
+  const String scopedBoardGameId = 'scoped-bg';
+  const String playthroughBoardGameId = 'bg1';
+  const String playthroughId = 'p1';
+
+  Playthrough buildOriginalPlaythrough({required List<String> scoreIds}) => Playthrough(
+        id: playthroughId,
+        boardGameId: playthroughBoardGameId,
+        playerIds: const ['pl1'],
+        scoreIds: scoreIds,
+        startDate: clock.now(),
+      );
+
+  late GamePlaythroughsDetailsStore store;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeScore());
+    registerFallbackValue(_FakePlaythrough());
+  });
+
+  setUp(() {
+    when(() => mockBoardGamesStore.allBoardGamesMap).thenReturn(
+      ObservableMap.of(
+        {scopedBoardGameId: const BoardGameDetails(id: scopedBoardGameId, name: 'Scoped')},
+      ),
+    );
+    when(() => mockPlaythroughsStore.updatePlaythrough(any())).thenAnswer((_) async => true);
+    when(() => mockScoresStore.addOrUpdateScore(any())).thenAnswer((_) async => true);
+    when(() => mockScoresStore.deleteScore(any())).thenAnswer((_) async {});
+
+    store = GamePlaythroughsDetailsStore(
+      mockPlaythroughsStore,
+      mockScoresStore,
+      mockPlayersStore,
+      mockBoardGamesStore,
+    );
+    store.setBoardGameId(scopedBoardGameId);
+  });
+
+  tearDown(() {
+    reset(mockPlaythroughsStore);
+    reset(mockScoresStore);
+    reset(mockPlayersStore);
+    reset(mockBoardGamesStore);
+  });
+
+  // SUSPECT A: the persistence loop iterates originalPlaythrough.scoreIds only, so a
+  // score whose id is not already in the original set is never written.
+  // NOTE: latent store bug — not reachable from the edit-playthrough page (no add-score
+  // affordance there), so it is not the #72 symptom, but is fixed as part of #72's scope.
+  test(
+      'GIVEN a playthrough gains a new player score '
+      'WHEN the playthrough is updated '
+      'THEN the newly added score is persisted too', () async {
+    final original = buildOriginalPlaythrough(scoreIds: const ['s1']);
+    when(() => mockPlaythroughsStore.playthroughs)
+        .thenReturn(ObservableList.of([original]));
+
+    final details = PlaythroughDetails(
+      playthrough: original,
+      playerScores: [
+        const PlayerScore(
+          player: Player(id: 'pl1'),
+          score: Score(
+            id: 's1',
+            playerId: 'pl1',
+            boardGameId: playthroughBoardGameId,
+            scoreGameResult: ScoreGameResult(points: 10),
+          ),
+        ),
+        const PlayerScore(
+          player: Player(id: 'pl2'),
+          score: Score(
+            id: 's2',
+            playerId: 'pl2',
+            boardGameId: playthroughBoardGameId,
+            scoreGameResult: ScoreGameResult(points: 8),
+          ),
+        ),
+      ],
+    );
+
+    await store.updatePlaythrough(details);
+
+    final persistedScoreIds = verify(() => mockScoresStore.addOrUpdateScore(captureAny()))
+        .captured
+        .cast<Score>()
+        .map((score) => score.id)
+        .toList();
+    expect(persistedScoreIds, containsAll(<String>['s1', 's2']));
+  });
+
+  // SUSPECT E: scores are matched by `score.id == scoreId`. A score that has not yet been
+  // assigned a persisted id (empty id) fails to match its original id and is treated as a
+  // deletion instead of being saved. (Score.id is non-nullable, so the reachable variant
+  // of the original "null id" suspect is the empty/unassigned id.)
+  // NOTE: same root cause / reachability caveat as Suspect A.
+  test(
+      'GIVEN an edited score has not been assigned a persisted id yet '
+      'WHEN the playthrough is updated '
+      'THEN the edited score is still persisted (not silently dropped)', () async {
+    final original = buildOriginalPlaythrough(scoreIds: const ['s1']);
+    when(() => mockPlaythroughsStore.playthroughs)
+        .thenReturn(ObservableList.of([original]));
+
+    final details = PlaythroughDetails(
+      playthrough: original,
+      playerScores: [
+        const PlayerScore(
+          player: Player(id: 'pl1'),
+          score: Score(
+            id: '',
+            playerId: 'pl1',
+            boardGameId: playthroughBoardGameId,
+            scoreGameResult: ScoreGameResult(points: 12),
+          ),
+        ),
+      ],
+    );
+
+    await store.updatePlaythrough(details);
+
+    final persistedScores = verify(() => mockScoresStore.addOrUpdateScore(captureAny()))
+        .captured
+        .cast<Score>();
+    expect(persistedScores.any((score) => score.score == 12), isTrue);
+  });
+}

--- a/board_games_companion/test/view_models/edit_playthrough_view_model_test.dart
+++ b/board_games_companion/test/view_models/edit_playthrough_view_model_test.dart
@@ -17,6 +17,8 @@ import 'package:mocktail/mocktail.dart';
 
 import '../mocks/game_playthroughs_details_store_mock.dart';
 
+class _FakePlaythroughDetails extends Fake implements PlaythroughDetails {}
+
 void main() {
   final mockGamePlaythroughsDetailsStore = MockGamePlaythroughsDetailsStore();
 
@@ -43,6 +45,10 @@ void main() {
   );
 
   late EditPlaythoughViewModel editPlaythrouhgViewModel;
+
+  setUpAll(() {
+    registerFallbackValue(_FakePlaythroughDetails());
+  });
 
   setUp(() {
     when(() => mockGamePlaythroughsDetailsStore.playthroughsDetails).thenReturn(
@@ -257,5 +263,84 @@ void main() {
       expect(editPlaythrouhgViewModel.editPlaythroughPageVisualState,
           const EditPlaythroughPageVisualStates.editScoreGame(gameFamily: gameFamily));
     });
+  });
+
+  // SUSPECT B: the updatePlayerScore guard early-returns when `hasResult && score == newScore`.
+  // For a score still stored in the deprecated `value` format, re-entering the same number is
+  // swallowed and the score is never migrated to a ScoreGameResult. The narrowed guard should
+  // only skip when the fully resolved PlayerScore is unchanged.
+  test(
+      'GIVEN a player score stored in the deprecated value format '
+      'WHEN re-entering the same numeric score '
+      'THEN the score is migrated to a ScoreGameResult (guard must not swallow it) ', () {
+    const playerId = '1';
+    when(() => mockGamePlaythroughsDetailsStore.playthroughsDetails).thenReturn(
+      ObservableList.of(
+        [
+          mockPlaythroughDetails.copyWith(
+            playerScores: [
+              emptyPlayerScore.copyWith(
+                player: const Player(id: playerId),
+                // ignore: deprecated_member_use_from_same_package
+                score: emptyScore.copyWith(value: '10'),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+
+    editPlaythrouhgViewModel.setPlaythroughId(mockPlaythroughId);
+    editPlaythrouhgViewModel.updatePlayerScore(playerId, 10.0);
+
+    final updatedPlayerScore = editPlaythrouhgViewModel.playerScores
+        .firstWhereOrNull((element) => element.id == playerId);
+    expect(updatedPlayerScore!.score.scoreGameResult?.points, 10.0);
+  });
+
+  // SUSPECT C: a score edit must mark the working copy dirty AND, on save, persist exactly
+  // once via the store. Regression guard for the "save silently no-ops" failure mode.
+  test(
+      'GIVEN a player score has been edited '
+      'WHEN saving changes '
+      'THEN the working copy is dirty and is persisted exactly once ', () async {
+    when(() => mockGamePlaythroughsDetailsStore.updatePlaythrough(any()))
+        .thenAnswer((_) async {});
+
+    editPlaythrouhgViewModel.setPlaythroughId(mockPlaythroughId);
+    editPlaythrouhgViewModel.updatePlayerScore(mockEmptyPlayerScoreId, 15.0);
+
+    expect(editPlaythrouhgViewModel.isDirty, isTrue);
+
+    await editPlaythrouhgViewModel.saveChanges();
+
+    verify(() => mockGamePlaythroughsDetailsStore.updatePlaythrough(any())).called(1);
+  });
+
+  // SUSPECT D: places are only recomputed when every player has a numerical score
+  // (finishedScoring). This test LOCKS the current behaviour for partially scored plays.
+  test(
+      'GIVEN not all players have a numerical score '
+      'WHEN updating a single player score '
+      'THEN no places are computed (current behaviour is locked) ', () {
+    when(() => mockGamePlaythroughsDetailsStore.playthroughsDetails).thenReturn(
+      ObservableList.of(
+        [
+          mockPlaythroughDetails.copyWith(
+            playerScores: [
+              emptyPlayerScore.copyWith(player: const Player(id: '1'), score: emptyScore),
+              emptyPlayerScore.copyWith(player: const Player(id: '2'), score: emptyScore),
+            ],
+          )
+        ],
+      ),
+    );
+
+    editPlaythrouhgViewModel.setPlaythroughId(mockPlaythroughId);
+    editPlaythrouhgViewModel.updatePlayerScore('1', 10.0);
+
+    for (final playerScore in editPlaythrouhgViewModel.playerScores) {
+      expect(playerScore.place, isNull);
+    }
   });
 }


### PR DESCRIPTION
Fixes #72.

## Problem
Scores could partially fail to save when editing a playthrough. Using a TDD pass across two seams (view model + store), five suspects were characterised — three were genuine defects, two are now locked as regression guards.

## Fixes
- **`updatePlayerScore` guard (the user-visible defect)** — it early-returned on `hasResult && score == newScore`, swallowing legitimate edits (e.g. a deprecated `value`-format score never migrating to a `ScoreGameResult`). Narrowed to skip only a true no-op (`scoreGameResult?.points == newScore`).
- **Store persistence loop** — it iterated the *original* `scoreIds`, so a newly-added score (or one without a persisted id yet) was silently dropped. It now persists **every** current player score, then deletes only the originals that are genuinely gone.

## Tests
| Suspect | Seam | Result |
|---|---|---|
| Guard swallows edit | view model | fixed (was red) |
| New score dropped | store | fixed (was red) |
| Unassigned-id score dropped | store | fixed (was red) |
| Dirty + single-persist round-trip | view model | green guard |
| Partial-scoring places | view model | green guard |

- `edit_playthrough_view_model_test.dart` (extended) + new `game_playthroughs_details_store_test.dart` — **12 pass**
- New mocks: `players_/playthroughs_/scores_store_mock.dart`
- Analyzer clean on all touched files.

## Notes
- The two store fixes (new-score and unassigned-id) are real bugs but **not reachable from the edit-playthrough page** (no add-score affordance there); fixed within #72's scope.
- Pre-existing, unrelated suite failure: `board_game_details_page_test.dart` fails to compile because `font_awesome_flutter 10.12.0` extends `IconData`, now a `final` class in this SDK. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)