### PR TITLE
fix: request store reviews silently, capped 3× a year (#39)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,3 +94,25 @@ _Avoid_: Worst matchup, bogey player
 **Buddy**:
 A player someone has shared the most playthroughs with, of any kind. Measures company kept, not results, so co-op plays count exactly as much as competitive ones.
 _Avoid_: Frequent player, teammate, partner
+
+### Ratings
+
+**In-app review**:
+The platform's own review prompt, shown by the OS on top of the app so the user can rate without leaving it. Best-effort and quota-limited — the OS decides whether to show it and never reports back — so it is asked for silently at an engagement checkpoint, never behind a button.
+_Avoid_: Rate dialog, review popup, rating prompt
+
+**Engagement criteria**:
+The conditions that make a user eligible for an in-app review — installed 14 days, launched at least 30 seconds ago, and at least 300 significant actions. Meeting them makes an attempt due; it does not guarantee a prompt is shown.
+_Avoid_: Rating threshold, trigger conditions
+
+**Significant action**:
+A user action meaningful enough to count towards the engagement criteria, such as logging a play or editing a collection entry. Counted up to the criteria's ceiling and no further.
+_Avoid_: Interaction, event, tap
+
+**Review request**:
+A single silent attempt to surface the in-app review. Its timestamp is recorded whether or not a prompt actually appears, because the OS never says. Attempts are capped at three a year and spaced roughly a third of a year apart.
+_Avoid_: Review shown, rating impression, prompt
+
+**Store listing**:
+The app's full page on the App Store or Google Play, opened directly in response to a deliberate "rate us" action (the home drawer's Rate & Review item). Distinct from an in-app review, which the OS overlays without leaving the app.
+_Avoid_: Store page, app page, product page

--- a/board_games_companion/lib/common/app_text.dart
+++ b/board_games_companion/lib/common/app_text.dart
@@ -3,9 +3,6 @@ class AppText {
   static const appTitle = 'Board Games Companion';
 
   static const rateAndReview = 'Rate & Review';
-  static const rate = 'Rate';
-  static const askMeLater = 'Ask me later';
-  static const aontAskAgain = "Don't ask again";
 
   static const cancel = 'Cancel';
   static const stop = 'Stop';

--- a/board_games_companion/lib/injectable.config.dart
+++ b/board_games_companion/lib/injectable.config.dart
@@ -11,6 +11,7 @@
 import 'package:firebase_analytics/firebase_analytics.dart' as _i398;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:hive/hive.dart' as _i979;
+import 'package:in_app_review/in_app_review.dart' as _i553;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:screenshot/screenshot.dart' as _i592;
 
@@ -76,15 +77,16 @@ _i174.GetIt $initGetIt(
   gh.factory<_i181.PlaythroughNoteViewModel>(
       () => _i181.PlaythroughNoteViewModel());
   gh.factory<_i979.HiveInterface>(() => registerModule.hive);
-  gh.singleton<_i207.FileService>(() => _i207.FileService());
+  gh.singleton<_i947.AppStore>(() => _i947.AppStore());
   gh.singleton<_i398.FirebaseAnalytics>(() => registerModule.firebaseAnalytics);
+  gh.singleton<_i553.InAppReview>(() => registerModule.inAppReview);
   gh.singleton<_i398.FirebaseAnalyticsObserver>(
       () => registerModule.firebaseAnalyticsObserver);
   gh.singleton<_i566.EnvironmentService>(
       () => registerModule.environmentService);
   gh.singleton<_i667.BoardGamesGeekService>(
       () => registerModule.boardGameGeekService);
-  gh.singleton<_i947.AppStore>(() => _i947.AppStore());
+  gh.singleton<_i207.FileService>(() => _i207.FileService());
   gh.singleton<_i927.BoardGamesService>(() => _i927.BoardGamesService(
         gh<_i979.HiveInterface>(),
         gh<_i667.BoardGamesGeekService>(),
@@ -97,29 +99,23 @@ _i174.GetIt $initGetIt(
       ));
   gh.singleton<_i75.BoardGamesSearchService>(
       () => _i75.BoardGamesSearchService(gh<_i566.EnvironmentService>()));
-  gh.singleton<_i701.PreferencesService>(
-      () => _i701.PreferencesService(gh<_i979.HiveInterface>()));
-  gh.singleton<_i277.ScoreService>(
-      () => _i277.ScoreService(gh<_i979.HiveInterface>()));
   gh.singleton<_i153.SearchService>(
       () => _i153.SearchService(gh<_i979.HiveInterface>()));
   gh.singleton<_i2.UserService>(
       () => _i2.UserService(gh<_i979.HiveInterface>()));
-  gh.singleton<_i93.RateAndReviewService>(
-      () => _i93.RateAndReviewService(gh<_i701.PreferencesService>()));
-  gh.singleton<_i385.AnalyticsService>(() => _i385.AnalyticsService(
-        gh<_i398.FirebaseAnalytics>(),
-        gh<_i93.RateAndReviewService>(),
+  gh.singleton<_i277.ScoreService>(
+      () => _i277.ScoreService(gh<_i979.HiveInterface>()));
+  gh.singleton<_i701.PreferencesService>(
+      () => _i701.PreferencesService(gh<_i979.HiveInterface>()));
+  gh.singleton<_i93.RateAndReviewService>(() => _i93.RateAndReviewService(
+        gh<_i701.PreferencesService>(),
+        gh<_i553.InAppReview>(),
       ));
   gh.singleton<_i182.PlayersStore>(
       () => _i182.PlayersStore(gh<_i29.PlayerService>()));
   gh.singleton<_i934.PlaythroughService>(() => _i934.PlaythroughService(
         gh<_i979.HiveInterface>(),
         gh<_i277.ScoreService>(),
-      ));
-  gh.singleton<_i981.BoardGamesFiltersStore>(() => _i981.BoardGamesFiltersStore(
-        gh<_i212.BoardGamesFiltersService>(),
-        gh<_i385.AnalyticsService>(),
       ));
   gh.singleton<_i78.UserStore>(() => _i78.UserStore(gh<_i2.UserService>()));
   gh.singleton<_i145.ScoresStore>(
@@ -130,12 +126,9 @@ _i174.GetIt $initGetIt(
         gh<_i934.PlaythroughService>(),
         gh<_i145.ScoresStore>(),
       ));
-  gh.factory<_i328.AnalyticsRouteObserver>(
-      () => _i328.AnalyticsRouteObserver(gh<_i385.AnalyticsService>()));
-  gh.singleton<_i115.ScreenshotGenerator>(() => _i115.ScreenshotGenerator(
-        screenshotController: gh<_i592.ScreenshotController>(),
-        rateAndReviewService: gh<_i93.RateAndReviewService>(),
-        analyticsService: gh<_i385.AnalyticsService>(),
+  gh.singleton<_i385.AnalyticsService>(() => _i385.AnalyticsService(
+        gh<_i398.FirebaseAnalytics>(),
+        gh<_i93.RateAndReviewService>(),
       ));
   gh.singleton<_i839.BoardGamesStore>(() => _i839.BoardGamesStore(
         gh<_i927.BoardGamesService>(),
@@ -148,12 +141,12 @@ _i174.GetIt $initGetIt(
         gh<_i145.ScoresStore>(),
         gh<_i385.AnalyticsService>(),
       ));
-  gh.factory<_i316.PlayerViewModel>(
-      () => _i316.PlayerViewModel(gh<_i182.PlayersStore>()));
   gh.factory<_i441.PlayersViewModel>(
       () => _i441.PlayersViewModel(gh<_i182.PlayersStore>()));
   gh.factory<_i950.PlaythroughPlayersSelectionViewModel>(() =>
       _i950.PlaythroughPlayersSelectionViewModel(gh<_i182.PlayersStore>()));
+  gh.factory<_i316.PlayerViewModel>(
+      () => _i316.PlayerViewModel(gh<_i182.PlayersStore>()));
   gh.singleton<_i585.SettingsViewModel>(() => _i585.SettingsViewModel(
         gh<_i207.FileService>(),
         gh<_i927.BoardGamesService>(),
@@ -166,6 +159,10 @@ _i174.GetIt $initGetIt(
         gh<_i947.AppStore>(),
         gh<_i78.UserStore>(),
         gh<_i839.BoardGamesStore>(),
+      ));
+  gh.singleton<_i981.BoardGamesFiltersStore>(() => _i981.BoardGamesFiltersStore(
+        gh<_i212.BoardGamesFiltersService>(),
+        gh<_i385.AnalyticsService>(),
       ));
   gh.singleton<_i791.GamePlaythroughsDetailsStore>(
       () => _i791.GamePlaythroughsDetailsStore(
@@ -202,6 +199,8 @@ _i174.GetIt $initGetIt(
         gh<_i927.BoardGamesService>(),
         gh<_i78.UserStore>(),
       ));
+  gh.factory<_i328.AnalyticsRouteObserver>(
+      () => _i328.AnalyticsRouteObserver(gh<_i385.AnalyticsService>()));
   gh.factory<_i85.CollectionSearchResultViewModel>(
       () => _i85.CollectionSearchResultViewModel(gh<_i839.BoardGamesStore>()));
   gh.factory<_i545.CreateBoardGameViewModel>(
@@ -216,6 +215,11 @@ _i174.GetIt $initGetIt(
         gh<_i145.ScoresStore>(),
         gh<_i85.PlaythroughsStore>(),
         gh<_i182.PlayersStore>(),
+      ));
+  gh.singleton<_i115.ScreenshotGenerator>(() => _i115.ScreenshotGenerator(
+        screenshotController: gh<_i592.ScreenshotController>(),
+        rateAndReviewService: gh<_i93.RateAndReviewService>(),
+        analyticsService: gh<_i385.AnalyticsService>(),
       ));
   gh.factory<_i368.EditPlaythoughViewModel>(() =>
       _i368.EditPlaythoughViewModel(gh<_i791.GamePlaythroughsDetailsStore>()));

--- a/board_games_companion/lib/pages/base_page_state.dart
+++ b/board_games_companion/lib/pages/base_page_state.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../common/app_colors.dart';
-import '../common/app_text.dart';
-import '../common/dimensions.dart';
 import '../injectable.dart';
 import '../services/rate_and_review_service.dart';
 
@@ -16,81 +13,15 @@ abstract class BasePageState<T extends StatefulWidget> extends State<T> {
     rateAndReviewService = getIt<RateAndReviewService>();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!rateAndReviewService.showRateAndReviewDialog) {
+      if (!rateAndReviewService.shouldRequestReview) {
         return;
       }
 
-      // MK Wait for all of the animations to finish before showing the dialog
+      // MK Let the launch animations settle before asking the OS to surface its
+      // native review prompt.
       await Future<dynamic>.delayed(const Duration(seconds: 1));
 
-      // ignore: use_build_context_synchronously
-      await _showRateAndReviewDialog(context);
+      await rateAndReviewService.requestReview();
     });
-  }
-
-  Future<void> _showRateAndReviewDialog(BuildContext context) async {
-    await showDialog<AlertDialog>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text(AppText.rateAndReview),
-          content: const Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                  "We apologise that we're interupting you but we would really appreciate your support.\n"),
-              Text(
-                  "If you're enjoying ${AppText.appTitle} app, would you mind taking a moment to rate it? It shouldn't take more than a minute.\n"),
-              Text('Thank you.'),
-            ],
-          ),
-          elevation: Dimensions.defaultElevation,
-          actions: [
-            TextButton(
-              child: const Text(
-                AppText.aontAskAgain,
-                style: TextStyle(
-                  color: AppColors.accentColor,
-                ),
-              ),
-              onPressed: () async {
-                Navigator.of(context).pop();
-
-                await rateAndReviewService.dontAskAgain();
-              },
-            ),
-            TextButton(
-              child: const Text(
-                AppText.askMeLater,
-                style: TextStyle(
-                  color: AppColors.accentColor,
-                ),
-              ),
-              onPressed: () async {
-                Navigator.of(context).pop();
-
-                await rateAndReviewService.askMeLater();
-              },
-            ),
-            TextButton(
-              style: TextButton.styleFrom(backgroundColor: AppColors.accentColor),
-              onPressed: () async {
-                Navigator.of(context).pop();
-
-                await rateAndReviewService.requestReview();
-              },
-              child: const Text(
-                AppText.rate,
-                style: TextStyle(
-                  color: AppColors.defaultTextColor,
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
   }
 }

--- a/board_games_companion/lib/services/injectable_register_module.dart
+++ b/board_games_companion/lib/services/injectable_register_module.dart
@@ -5,6 +5,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:hive/hive.dart';
 import 'package:http/http.dart';
+import 'package:in_app_review/in_app_review.dart';
 import 'package:injectable/injectable.dart';
 
 import 'environment_service.dart';
@@ -21,6 +22,9 @@ abstract class RegisterModule {
 
   @injectable
   HiveInterface get hive => Hive;
+
+  @singleton
+  InAppReview get inAppReview => InAppReview.instance;
 
   @singleton
   FirebaseAnalyticsObserver get firebaseAnalyticsObserver =>

--- a/board_games_companion/lib/services/preferences_service.dart
+++ b/board_games_companion/lib/services/preferences_service.dart
@@ -8,9 +8,8 @@ class PreferencesService extends BaseHiveService<dynamic, PreferencesService> {
 
   static const String _firstTimeAppLaunchDateKey = 'firstTimeLaunchDate';
   static const String _appLaunchDateKey = 'applaunchDate';
-  static const String _remindMeLaterDateKey = 'remindMeLater';
   static const String _numberOfSignificantActionsKey = 'numberOfSignificantActions';
-  static const String _rateAndReviewDialogSeenKey = 'rateAndReviewDialogSeen';
+  static const String _lastReviewRequestDateKey = 'lastReviewRequestDate';
   static const String _expansionsPanelExpandedStateKey = 'expansionsPanelExpandedState';
 
   Future<void> initialize() async {
@@ -24,10 +23,6 @@ class PreferencesService extends BaseHiveService<dynamic, PreferencesService> {
     }
 
     await _setValue(_appLaunchDateKey, nowUtc);
-  }
-
-  Future<void> setRemindMeLaterDate(DateTime remindMeLaterDate) async {
-    await _setValue(_remindMeLaterDateKey, remindMeLaterDate);
   }
 
   DateTime? getFirstTimeLaunchDate() {
@@ -44,25 +39,15 @@ class PreferencesService extends BaseHiveService<dynamic, PreferencesService> {
     );
   }
 
-  DateTime? getRemindMeLaterDate() {
+  DateTime? getLastReviewRequestDate() {
     return _getValue(
-      _remindMeLaterDateKey,
+      _lastReviewRequestDateKey,
       defaultValue: null,
     );
   }
 
-  bool getRateAndReviewDialogSeen() {
-    return _getValue(
-      _rateAndReviewDialogSeenKey,
-      defaultValue: false,
-    )!;
-  }
-
-  Future<void> setRateAndReviewDialogSeen() async {
-    await _setValue(
-      _rateAndReviewDialogSeenKey,
-      true,
-    );
+  Future<void> setLastReviewRequestDate(DateTime lastReviewRequestDate) async {
+    await _setValue(_lastReviewRequestDateKey, lastReviewRequestDate);
   }
 
   int getNumberOfSignificantActions() {

--- a/board_games_companion/lib/services/rate_and_review_service.dart
+++ b/board_games_companion/lib/services/rate_and_review_service.dart
@@ -8,15 +8,23 @@ import 'preferences_service.dart';
 
 @singleton
 class RateAndReviewService {
-  RateAndReviewService(this._preferencesService);
+  RateAndReviewService(this._preferencesService, this._inAppReview);
 
   final PreferencesService _preferencesService;
+  final InAppReview _inAppReview;
+
   static const Duration _requiredAppUsedForDuration = Duration(days: 14);
-  static const Duration _remindMeLaterDuration = Duration(days: 7);
   static const Duration _requiredAppLaunchedForDuration = Duration(seconds: 30);
   static const int _requiredNumberOfSignificantActions = 300;
 
-  bool showRateAndReviewDialog = false;
+  // MK Both Apple and Google cap how often a review prompt is shown (Apple: at
+  // most 3 per app, per device, per 365-day period). We mirror that by only
+  // attempting a silent review at most 3 times a year, spacing attempts out
+  // evenly so we never waste one of the OS quota slots on a request that would
+  // be dropped anyway.
+  static const Duration _minDurationBetweenReviewRequests = Duration(days: 365 ~/ 3);
+
+  bool shouldRequestReview = false;
 
   Future<void> increaseNumberOfSignificantActions() async {
     int numberOfSignificantActions = _preferencesService.getNumberOfSignificantActions();
@@ -26,53 +34,44 @@ class RateAndReviewService {
       );
     }
 
-    await _updateShowRateAndReviewDialogFlag();
+    await _updateShouldRequestReviewFlag();
   }
 
+  /// Silently asks the platform to show its native in-app review prompt.
+  ///
+  /// Triggered at a natural checkpoint (never from a button), as both Apple and
+  /// Google require. The OS decides whether the prompt is actually shown, so
+  /// there is no user-facing dialog and no way to know if it appeared. For an
+  /// explicit "rate us" action, deep-link to the store listing instead.
   Future<void> requestReview() async {
-    showRateAndReviewDialog = false;
+    shouldRequestReview = false;
 
-    if (!await InAppReview.instance.isAvailable()) {
+    if (!await _inAppReview.isAvailable()) {
       return;
     }
 
-    await InAppReview.instance.requestReview();
-    await _preferencesService.setRateAndReviewDialogSeen();
+    await _inAppReview.requestReview();
+    await _preferencesService.setLastReviewRequestDate(DateTime.now().toUtc());
   }
 
-  Future<void> askMeLater() async {
-    showRateAndReviewDialog = false;
-    await _preferencesService
-        .setRemindMeLaterDate(DateTime.now().toUtc().add(_remindMeLaterDuration));
-  }
-
-  Future<void> dontAskAgain() async {
-    showRateAndReviewDialog = false;
-    await _preferencesService.setRateAndReviewDialogSeen();
-  }
-
-  Future<void> _updateShowRateAndReviewDialogFlag() async {
+  Future<void> _updateShouldRequestReviewFlag() async {
     try {
-      final bool rateAndReviewDialogSeen = _preferencesService.getRateAndReviewDialogSeen();
-      if (rateAndReviewDialogSeen) {
-        return;
-      }
-
       final DateTime nowUtc = DateTime.now().toUtc();
       final DateTime? firstTimeLaunchDate = _preferencesService.getFirstTimeLaunchDate();
       final DateTime? appLaunchDate = _preferencesService.getAppLaunchDate();
-      final DateTime? remindMeLaterDate = _preferencesService.getRemindMeLaterDate();
-      if (firstTimeLaunchDate == null || appLaunchDate == null || remindMeLaterDate == null) {
+      if (firstTimeLaunchDate == null || appLaunchDate == null) {
         return;
       }
 
+      final DateTime? lastReviewRequestDate = _preferencesService.getLastReviewRequestDate();
       final int numberOfSignificantActions = _preferencesService.getNumberOfSignificantActions();
 
-      showRateAndReviewDialog =
+      shouldRequestReview =
           firstTimeLaunchDate.add(_requiredAppUsedForDuration).isBefore(nowUtc) &&
               appLaunchDate.add(_requiredAppLaunchedForDuration).isBefore(nowUtc) &&
-              (remindMeLaterDate == null || remindMeLaterDate.isBefore(nowUtc)) &&
-              numberOfSignificantActions >= _requiredNumberOfSignificantActions;
+              numberOfSignificantActions >= _requiredNumberOfSignificantActions &&
+              (lastReviewRequestDate == null ||
+                  lastReviewRequestDate.add(_minDurationBetweenReviewRequests).isBefore(nowUtc));
     } catch (e, stack) {
       FirebaseCrashlytics.instance.recordError(e, stack);
     }

--- a/board_games_companion/test/mocks/in_app_review_mock.dart
+++ b/board_games_companion/test/mocks/in_app_review_mock.dart
@@ -1,0 +1,4 @@
+import 'package:in_app_review/in_app_review.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockInAppReview extends Mock implements InAppReview {}

--- a/board_games_companion/test/pages/board_game_details_page_test.dart
+++ b/board_games_companion/test/pages/board_game_details_page_test.dart
@@ -29,7 +29,7 @@ void main() {
   late final BoardGameDetailsViewModel viewModel;
 
   setUp(() {
-    when(() => mockRateAndReviewService.showRateAndReviewDialog).thenReturn(false);
+    when(() => mockRateAndReviewService.shouldRequestReview).thenReturn(false);
     when(() => mockBoardGamesStore.allBoardGamesMap).thenReturn(ObservableMap.of({
       mockBoardGameId: mockBoardGame,
     }));

--- a/board_games_companion/test/services/rate_and_review_service_test.dart
+++ b/board_games_companion/test/services/rate_and_review_service_test.dart
@@ -1,0 +1,119 @@
+import 'package:board_games_companion/services/rate_and_review_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/in_app_review_mock.dart';
+import '../mocks/preference_service_mock.dart';
+
+void main() {
+  late MockPreferencesService mockPreferencesService;
+  late MockInAppReview mockInAppReview;
+  late RateAndReviewService rateAndReviewService;
+
+  DateTime daysAgo(int days) => DateTime.now().toUtc().subtract(Duration(days: days));
+
+  void stubEligible({
+    DateTime? firstTimeLaunchDate,
+    DateTime? appLaunchDate,
+    DateTime? lastReviewRequestDate,
+    int numberOfSignificantActions = 300,
+  }) {
+    when(() => mockPreferencesService.getFirstTimeLaunchDate())
+        .thenReturn(firstTimeLaunchDate ?? daysAgo(30));
+    when(() => mockPreferencesService.getAppLaunchDate())
+        .thenReturn(appLaunchDate ?? daysAgo(1));
+    when(() => mockPreferencesService.getLastReviewRequestDate())
+        .thenReturn(lastReviewRequestDate);
+    when(() => mockPreferencesService.getNumberOfSignificantActions())
+        .thenReturn(numberOfSignificantActions);
+    when(() => mockPreferencesService.setNumberOfSignificantActions(any()))
+        .thenAnswer((_) => Future.value());
+  }
+
+  setUpAll(() {
+    registerFallbackValue(DateTime.now().toUtc());
+  });
+
+  setUp(() {
+    mockPreferencesService = MockPreferencesService();
+    mockInAppReview = MockInAppReview();
+    when(() => mockInAppReview.isAvailable()).thenAnswer((_) async => true);
+    when(() => mockInAppReview.requestReview()).thenAnswer((_) => Future.value());
+    when(() => mockPreferencesService.setLastReviewRequestDate(any()))
+        .thenAnswer((_) => Future.value());
+    rateAndReviewService = RateAndReviewService(mockPreferencesService, mockInAppReview);
+  });
+
+  group('requestReview', () {
+    test('silently triggers the native in-app review when available', () async {
+      await rateAndReviewService.requestReview();
+
+      verify(() => mockInAppReview.requestReview()).called(1);
+    });
+
+    test('records the attempt timestamp so future attempts can be rate limited', () async {
+      await rateAndReviewService.requestReview();
+
+      verify(() => mockPreferencesService.setLastReviewRequestDate(any())).called(1);
+    });
+
+    test('does nothing and records no attempt when in-app review is unavailable', () async {
+      when(() => mockInAppReview.isAvailable()).thenAnswer((_) async => false);
+
+      await rateAndReviewService.requestReview();
+
+      verifyNever(() => mockInAppReview.requestReview());
+      verifyNever(() => mockPreferencesService.setLastReviewRequestDate(any()));
+    });
+
+    test('clears the should request review flag', () async {
+      rateAndReviewService.shouldRequestReview = true;
+
+      await rateAndReviewService.requestReview();
+
+      expect(rateAndReviewService.shouldRequestReview, isFalse);
+    });
+  });
+
+  group('shouldRequestReview eligibility', () {
+    test('is true once all criteria are met and no attempt was ever made', () async {
+      stubEligible(lastReviewRequestDate: null);
+
+      await rateAndReviewService.increaseNumberOfSignificantActions();
+
+      expect(rateAndReviewService.shouldRequestReview, isTrue);
+    });
+
+    test('is false when the app has not been used long enough', () async {
+      stubEligible(firstTimeLaunchDate: daysAgo(2));
+
+      await rateAndReviewService.increaseNumberOfSignificantActions();
+
+      expect(rateAndReviewService.shouldRequestReview, isFalse);
+    });
+
+    test('is false when there are not enough significant actions', () async {
+      stubEligible(numberOfSignificantActions: 100);
+
+      await rateAndReviewService.increaseNumberOfSignificantActions();
+
+      expect(rateAndReviewService.shouldRequestReview, isFalse);
+    });
+
+    test('is false when an attempt was made recently (3 per year cap)', () async {
+      stubEligible(lastReviewRequestDate: daysAgo(10));
+
+      await rateAndReviewService.increaseNumberOfSignificantActions();
+
+      expect(rateAndReviewService.shouldRequestReview, isFalse);
+    });
+
+    test('is true again once enough time has passed since the last attempt', () async {
+      stubEligible(lastReviewRequestDate: daysAgo(130));
+
+      await rateAndReviewService.increaseNumberOfSignificantActions();
+
+      expect(rateAndReviewService.shouldRequestReview, isTrue);
+    });
+  });
+}

--- a/docs/adr/0005-silent-in-app-review-capped-per-year.md
+++ b/docs/adr/0005-silent-in-app-review-capped-per-year.md
@@ -1,0 +1,33 @@
+# Ask for a store rating with a silent, quota-aware in-app review, not a custom dialog
+
+We ask for a store rating by triggering the platform's **native review prompt** silently at an engagement checkpoint, and never more than three times a year. The app no longer shows its own "Rate / Ask me later / Don't ask again" dialog before the review ([#39](https://github.com/Progrunning/BoardGamesCompanion/issues/39)).
+
+## Status
+
+accepted
+
+## Context
+
+The engagement criteria — app installed 14 days, launched 30 seconds ago, at least 300 significant actions — decide when we want a rating. Previously, meeting them raised a flag that made `BasePageState` show a custom `AlertDialog`, and only the **Rate** button called `InAppReview.requestReview()`.
+
+That coupling is the bug. Both stores treat the in-app review flow as best-effort and quota-limited: Apple shows the prompt at most three times per app, per device, per 365-day period, and Google enforces its own undocumented quota. Neither reports back whether the prompt was actually shown. Both explicitly say the flow must fire at a natural moment and must **not** be attached to a button — so a user who has already been prompted three times, or whose quota is spent, taps our **Rate** button and sees nothing. The custom dialog manufactured exactly the anti-pattern the platforms warn against.
+
+## Considered options
+
+- **Custom dialog, Rate button opens the store listing** (rejected: it fixes the "nothing happens" symptom by abandoning the native in-app prompt entirely, sending every willing user out to the full store page. It keeps a modal that interrupts the user to ask a question the OS is designed to ask unobtrusively, and it still gates a review on a button — the thing both stores tell you not to do).
+- **Silent native prompt at the checkpoint, no dialog** (accepted: the OS decides whether and how to show the prompt, at a moment the user is already engaged, with no interruption when the quota is spent. This is the intended pattern on both platforms from one `InAppReview.requestReview()` call).
+- **No client-side rate limit, rely on OS quotas** (rejected: we would call `requestReview()` on many launches once eligible, spending OS quota slots on requests that get silently dropped and learning nothing. A client-side cadence keeps each attempt meaningful).
+
+## Decision
+
+- On reaching the engagement criteria, `BasePageState` calls `RateAndReviewService.requestReview()` after the launch animations settle. There is no dialog and no user-facing choice.
+- `requestReview()` asks the OS to show its native prompt (guarded by `isAvailable()`) and records the attempt timestamp. It shows nothing itself.
+- Eligibility additionally requires that the **last review request** was either never made or is older than a third of a year (`365 ~/ 3` ≈ 121 days), so we attempt at most three times a year and space the attempts evenly against the OS quota rather than bunching them.
+- An explicit "rate us" affordance — the home drawer's **Rate & Review** item — deep-links to the store listing (`openStoreListing`), which is the correct response to a deliberate user action on both platforms and is unaffected by this decision.
+
+## Consequences
+
+- **"Ask me later" and "Don't ask again" no longer exist.** With no dialog there is nowhere to offer them, so `askMeLater`, `dontAskAgain`, the `remindMeLater` preference, and the dialog strings were removed. Users who dislike the prompt use the OS-level setting (Apple: App Store → In-App Ratings & Reviews) to turn it off globally.
+- **"Seen" became a timestamp, not a boolean.** A permanent "dialog seen" flag is incompatible with prompting again three times a year, so the single source of truth for cadence is the **last review request** timestamp. The old boolean preference is gone.
+- **We never learn whether a prompt was shown.** The OS gives no callback, so the recorded timestamp marks an *attempt*, not a confirmed impression. A spent quota looks identical to a shown prompt. This is inherent to both platforms and is why the client-side cadence exists.
+- **The rate limit is time-based, not a counter.** Three attempts a year falls out of the ~121-day spacing rather than a "requests this year" count, which keeps the rule to one stored timestamp and no rollover bookkeeping.


### PR DESCRIPTION
Closes #39.

## Problem
Meeting the engagement criteria raised a flag that showed a custom **Rate / Ask me later / Don't ask again** dialog, and only the **Rate** button called `InAppReview.requestReview()`. Both stores treat the in-app review flow as best-effort and quota-limited (Apple: ≤3 prompts per app/device/365 days; Google: its own quota), never report whether the prompt was shown, and explicitly warn against gating it behind a button. So once quota was spent, a user tapping **Rate** saw nothing.

## Change
- Removed the custom dialog. `BasePageState` now calls `RateAndReviewService.requestReview()` **silently** at the post-frame checkpoint once the engagement criteria are met; the OS decides whether to show its native prompt.
- `requestReview()` is guarded by `isAvailable()` and records a **last-review-request** timestamp.
- Eligibility now also requires the last request be null or older than `365 ~/ 3` (~121) days, capping attempts at **three per year** and spacing them evenly against the OS quota.
- Replaced the permanent `rateAndReviewDialogSeen` boolean and the `remindMeLater` plumbing with the timestamp; removed `askMeLater` / `dontAskAgain` and their dead UI strings.
- The home drawer's explicit **Rate & Review** still deep-links to the store listing (`openStoreListing`) — unchanged, correct for a deliberate user action.

## Decision record
- New **ADR-0005** (`docs/adr/0005-silent-in-app-review-capped-per-year.md`).
- New **Ratings** section in `CONTEXT.md` (In-app review, Engagement criteria, Significant action, Review request, Store listing).

## Tests
New spec at the `RateAndReviewService` seam (silent-request behavior + all five eligibility cases including the 3/year cadence): **9/9 green**. Full suite: 49 pass, 1 pre-existing unrelated failure (`board_game_details_page_test.dart` fails to compile due to `font_awesome_flutter` 10.12.0 vs the newer Flutter SDK — `IconData` is now `final`; fails on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)